### PR TITLE
Fix bug where ttl parameter was unhandled correctly

### DIFF
--- a/cloudflare-dns.sh
+++ b/cloudflare-dns.sh
@@ -288,13 +288,14 @@ settings_domains_validation() {
     fi
 
     # Check validity of "ttl" parameter
-    if [ "${domains__ttl[i]}" -lt 120 ] 2>/dev/null ||
-      [ "${domains__ttl[i]}" -gt 7200 ] 2>/dev/null ||
-      [ "${domains__ttl[i]}" != "auto" ]; then
+    if [ "${domains__ttl[i]}" == "auto" ]; then
+      def_ttl_enabled[i]=false
+    elif [ "${domains__ttl[i]}" -gt 120 ] 2>/dev/null ||
+     [ "${domains_ttl[i]}" -lt 7200 ] 2>/dev/null; then
+      def_ttl_enabled[i]=false
+    else
       warn_msg "Error! 'ttl' out of range (120-7200) or not set to 'auto'. Force set to '$def_ttl'"
       def_ttl_enabled[i]=true
-    else
-      def_ttl_enabled[i]=false
     fi
 
     # Check validity of "proxied" parameter

--- a/cloudflare-dns.sh
+++ b/cloudflare-dns.sh
@@ -290,8 +290,8 @@ settings_domains_validation() {
     # Check validity of "ttl" parameter
     if [ "${domains__ttl[i]}" == "auto" ]; then
       def_ttl_enabled[i]=false
-    elif [ "${domains__ttl[i]}" -gt 120 ] 2>/dev/null ||
-     [ "${domains_ttl[i]}" -lt 7200 ] 2>/dev/null; then
+    elif [ "${domains__ttl[i]}" -ge 120 ] 2>/dev/null &&
+     [ "${domains__ttl[i]}" -le 7200 ] 2>/dev/null; then
       def_ttl_enabled[i]=false
     else
       warn_msg "Error! 'ttl' out of range (120-7200) or not set to 'auto'. Force set to '$def_ttl'"


### PR DESCRIPTION
As reported in [Issue #74](https://github.com/jmrplens/DynDNS_Cloudflare_IPv4-6/issues/74) by [dalgrim](https://github.com/dalgrim), the `ttl` parameter was not being handled correctly when set to a specific value other than `auto`.

**Cause:**
This issue was caused by a logical error in [this line](https://github.com/jmrplens/DynDNS_Cloudflare_IPv4-6/blob/d379abc0f750080e94ff18135fdf9a88d17e5c39/cloudflare-dns.sh#L293), where the condition `${domains_ttl[i]} != "auto"` always evaluated as true, even when `ttl` was set within the valid range of 120-7200 seconds.

**Fix:**
[dalgrim](https://github.com/dalgrim) proposed [a solution](https://github.com/jmrplens/DynDNS_Cloudflare_IPv4-6/issues/74#issuecomment-1909138773). I have implemented a similar fix by rewriting there logic with else if statements for better clarity.