### PR TITLE
fix: exclude ULA (fc/fd) IPv6 addresses from public IP detection

### DIFF
--- a/src/ip.sh
+++ b/src/ip.sh
@@ -19,22 +19,13 @@ get_ipv6_from_interface() {
 	if [[ -z "$iface" ]]; then return 1; fi
 
 	if command -v ip >/dev/null 2>&1; then
-		# Linux: Prefer 'global' scope, exclude 'deprecated' or 'temporary' if possible,
-		# but Cloudflare usually wants the permanent global address.
-		# We take the first 'scope global' address.
-		# 'ip -6 addr show dev eth0 scope global'
-		# Output format: "inet6 2001:db8::1/64 scope global ..."
-
-		# Try to find one that is NOT temporary (mngtmpaddr/dynamic) if possible,
-		# or just the first global one.
-		# User example: 2a0c:5a84:b906:6300:7a55:36ff:fe04:bb9a (looks like EUI-64 or random privacy, but global)
-
-		ip=$(ip -6 addr show dev "$iface" scope global | grep "inet6" | head -n1 | awk '{print $2}' | cut -d'/' -f1)
+		# Linux: Get global scope addresses, exclude ULA (fc00::/7 = fc/fd prefix)
+		# which have scope global in the kernel but are not publicly routable.
+		ip=$(ip -6 addr show dev "$iface" scope global | grep "inet6" | awk '{print $2}' | cut -d'/' -f1 | grep -v -i "^f[cd]" | head -n1)
 
 	elif command -v ifconfig >/dev/null 2>&1; then
-		# macOS / BSD
-		# Look for 'inet6', exclude 'fe80', take first.
-		ip=$(ifconfig "$iface" | grep "inet6 " | grep -v "fe80::" | head -n1 | awk '{print $2}' | cut -d'/' -f1)
+		# macOS / BSD: exclude link-local (fe80) and ULA (fc/fd prefix)
+		ip=$(ifconfig "$iface" | grep "inet6 " | grep -v "fe80::" | awk '{print $2}' | cut -d'/' -f1 | grep -v -i "^f[cd]" | head -n1)
 	fi
 
 	# Windows (via ipconfig in git bash/wsl? hard to parse reliable without powershell)

--- a/src/ip.sh
+++ b/src/ip.sh
@@ -21,11 +21,11 @@ get_ipv6_from_interface() {
 	if command -v ip >/dev/null 2>&1; then
 		# Linux: Get global scope addresses, exclude ULA (fc00::/7 = fc/fd prefix)
 		# which have scope global in the kernel but are not publicly routable.
-		ip=$(ip -6 addr show dev "$iface" scope global | grep "inet6" | awk '{print $2}' | cut -d'/' -f1 | grep -v -i "^f[cd]" | head -n1)
+		ip=$(ip -6 addr show dev "$iface" scope global | awk '/inet6 / { split($2, a, "/"); if (a[1] !~ /^[Ff][CcDd]/) { print a[1]; exit } }')
 
 	elif command -v ifconfig >/dev/null 2>&1; then
 		# macOS / BSD: exclude link-local (fe80) and ULA (fc/fd prefix)
-		ip=$(ifconfig "$iface" | grep "inet6 " | grep -v "fe80::" | awk '{print $2}' | cut -d'/' -f1 | grep -v -i "^f[cd]" | head -n1)
+		ip=$(ifconfig "$iface" | awk '/inet6 / && $2 !~ /^fe80/ && $2 !~ /^[Ff][CcDd]/ { split($2, a, "/"); print a[1]; exit }')
 	fi
 
 	# Windows (via ipconfig in git bash/wsl? hard to parse reliable without powershell)


### PR DESCRIPTION
## Problem

When detecting the current public IPv6 address, the script uses `ip -6 addr show scope global` which includes **ULA (Unique Local Address)** addresses with `fc`/`fd` prefixes. These addresses have `scope global` in the kernel but are **not publicly routable**.

This caused the updater to pick an internal IPv6 (e.g. `fdab:6dfe:8386:4244:...`) instead of the actual public GUA address (e.g. `2a0c:5a84:b302:b400:...`), and since a match was found, it **never fell back** to external services like icanhazip.com.

**Example log showing the bug:**
```
[INFO] Change detected for test.jmrp.io (AAAA): 2a0c:5a84:b302:b400:7a55:36ff:fe04:bb9a -> fdab:6dfe:8386:4244:1a43:3d0c:76c5:1993
```

## Fix

Filter out ULA addresses (`fc00::/7` — prefixes `fc` and `fd`) from the interface detection pipeline before selecting the first match. Applied to both Linux (`ip`) and macOS (`ifconfig`) code paths.

If no public IPv6 remains on the interface after filtering, the script correctly falls back to external detection services.

## Summary by Sourcery

Bug Fixes:
- Ignore IPv6 ULA (fc00::/7) addresses when selecting a public IPv6 from interfaces on Linux and macOS/BSD so internal addresses are not mistaken for public ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPv6 address selection on Linux and macOS/BSD to exclude unique local and link-local addresses, prioritizing publicly routable addresses for more reliable and consistent network connectivity across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->