### PR TITLE
chore: bump version to 1.1.2

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -32,7 +32,7 @@ logger_init "$LOG_PATH"
 # shellcheck source=src/cloudflare.sh
 
 # Project metadata
-VERSION="1.1.1"
+VERSION="1.1.2"
 updates_json_list=""
 update_count=0
 verification_list=()


### PR DESCRIPTION
Bump version to 1.1.2 to trigger a new release with the ULA IPv6 fix from #108.

## Summary by Sourcery

Chores:
- Update the recorded project version from 1.1.1 to 1.1.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project version to 1.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->