### PR TITLE
fix: prefer non-deprecated IPv6 and preserve parent flags

### DIFF
--- a/src/ip.sh
+++ b/src/ip.sh
@@ -19,9 +19,12 @@ get_ipv6_from_interface() {
 	if [[ -z "$iface" ]]; then return 1; fi
 
 	if command -v ip >/dev/null 2>&1; then
-		# Linux: Get global scope addresses, exclude ULA (fc00::/7 = fc/fd prefix)
-		# which have scope global in the kernel but are not publicly routable.
-		ip=$(ip -6 addr show dev "$iface" scope global | awk '/inet6 / { split($2, a, "/"); if (a[1] !~ /^[Ff][CcDd]/) { print a[1]; exit } }')
+		# Linux: Get global scope addresses, exclude ULA (fc00::/7 = fc/fd prefix).
+		# Prefer non-deprecated addresses; fall back to deprecated if none available.
+		ip=$(ip -6 addr show dev "$iface" scope global | grep -v deprecated | awk '/inet6 / { split($2, a, "/"); if (a[1] !~ /^[Ff][CcDd]/) { print a[1]; exit } }')
+		if [[ -z "$ip" ]]; then
+			ip=$(ip -6 addr show dev "$iface" scope global | awk '/inet6 / { split($2, a, "/"); if (a[1] !~ /^[Ff][CcDd]/) { print a[1]; exit } }')
+		fi
 
 	elif command -v ifconfig >/dev/null 2>&1; then
 		# macOS / BSD: exclude link-local (fe80) and ULA (fc/fd prefix)

--- a/src/ip.sh
+++ b/src/ip.sh
@@ -20,10 +20,10 @@ get_ipv6_from_interface() {
 
 	if command -v ip >/dev/null 2>&1; then
 		# Linux: Get global scope addresses, exclude ULA (fc00::/7 = fc/fd prefix).
-		# Prefer non-deprecated addresses; fall back to deprecated if none available.
+		# Filter out deprecated addresses — they should not be published in DNS.
 		ip=$(ip -6 addr show dev "$iface" scope global | grep -v deprecated | awk '/inet6 / { split($2, a, "/"); if (a[1] !~ /^[Ff][CcDd]/) { print a[1]; exit } }')
 		if [[ -z "$ip" ]]; then
-			ip=$(ip -6 addr show dev "$iface" scope global | awk '/inet6 / { split($2, a, "/"); if (a[1] !~ /^[Ff][CcDd]/) { print a[1]; exit } }')
+			echo "[WARNING] No valid (non-deprecated) IPv6 address found on interface '$iface'. AAAA records will not be updated." >&2
 		fi
 
 	elif command -v ifconfig >/dev/null 2>&1; then

--- a/src/ip.sh
+++ b/src/ip.sh
@@ -19,11 +19,24 @@ get_ipv6_from_interface() {
 	if [[ -z "$iface" ]]; then return 1; fi
 
 	if command -v ip >/dev/null 2>&1; then
-		# Linux: Get global scope addresses, exclude ULA (fc00::/7 = fc/fd prefix).
-		# Filter out deprecated addresses — they should not be published in DNS.
-		ip=$(ip -6 addr show dev "$iface" scope global | grep -v deprecated | awk '/inet6 / { split($2, a, "/"); if (a[1] !~ /^[Ff][CcDd]/) { print a[1]; exit } }')
+		# Linux: Get first global-scope, non-ULA IPv6 with preferred_lft > 0.
+		# Addresses with preferred_lft 0 are deprecated and must not be published in DNS.
+		ip=$(ip -6 addr show dev "$iface" scope global | awk '
+			/inet6 / {
+				split($2, a, "/")
+				if (a[1] !~ /^[Ff][CcDd]/) {
+					addr = a[1]
+					getline
+					for (i = 1; i <= NF; i++) {
+						if ($i == "preferred_lft") {
+							gsub(/sec$/, "", $(i+1))
+							if ($(i+1) + 0 > 0) { print addr; exit }
+						}
+					}
+				}
+			}')
 		if [[ -z "$ip" ]]; then
-			echo "[WARNING] No valid (non-deprecated) IPv6 address found on interface '$iface'. AAAA records will not be updated." >&2
+			log_warn "No valid (non-deprecated) IPv6 found on '$iface'. AAAA records will not be updated."
 		fi
 
 	elif command -v ifconfig >/dev/null 2>&1; then

--- a/src/main.sh
+++ b/src/main.sh
@@ -10,9 +10,9 @@ domains_ttl=()
 DOMAIN_COUNT=0
 CF_ZONE_ID=""
 CF_API_TOKEN=""
-DEBUG="false"
-FORCE="false"
-SILENT="false"
+DEBUG="${DEBUG:-false}"
+FORCE="${FORCE:-false}"
+SILENT="${SILENT:-false}"
 
 # Load Modules
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"

--- a/src/main.sh
+++ b/src/main.sh
@@ -32,7 +32,7 @@ logger_init "$LOG_PATH"
 # shellcheck source=src/cloudflare.sh
 
 # Project metadata
-VERSION="1.1.2"
+VERSION="1.1.3"
 updates_json_list=""
 update_count=0
 verification_list=()


### PR DESCRIPTION
## Summary

Two bugs fixed that caused **all 31 AAAA DNS records** to point to a wrong (deprecated) IPv6 address.

### Bug 1 — Deprecated IPv6 selected for DNS (Critical)

**File:** `src/ip.sh` — `get_ipv6_from_interface()`

**Problem:** The function uses `ip -6 addr show dev "$iface" scope global` and picks the first result. On systems with SLAAC where the ISP prefix has changed, deprecated addresses (from old prefixes) are listed first. The function selected a deprecated IPv6 that was no longer routable, causing all AAAA records to be wrong.

**Root cause:** Linux marks old-prefix SLAAC addresses as `deprecated` but they remain in the interface list. Without filtering, the updater picks these stale addresses.

**Fix:**
- Added `grep -v deprecated` before `awk` to filter out deprecated addresses
- If **all** global IPv6 addresses are deprecated, the function returns empty and logs a warning to stderr instead of silently publishing a bad address
- No fallback to deprecated addresses — a deprecated IP should never go into DNS

### Bug 2 — Parent script flags overridden

**File:** `src/main.sh`

**Problem:** Bare variable assignments (`DEBUG="false"`, `FORCE="false"`, `SILENT="false"`) unconditionally overwrite any exported values from the parent script `cloudflare-dns-updater.sh`. Running `./cloudflare-dns-updater.sh --debug` had no effect because `main.sh` immediately reset `DEBUG` to `"false"`.

**Fix:** Changed to parameter expansion with defaults:
```bash
DEBUG="${DEBUG:-false}"
FORCE="${FORCE:-false}"
SILENT="${SILENT:-false}"
```

### Impact

- All 62 DNS records (31 A + 31 AAAA) were successfully updated after applying these fixes
- Debug/force/silent flags now work correctly when passed from the parent script

### Related Issues

- Affects any system using SLAAC with changing ISP prefixes (common with DHCPv6-PD)
- The flag override bug has existed since the flags were added and made `--debug`, `--force`, `--silent` CLI options non-functional

## Summary by Sourcery

Fix IPv6 selection and flag handling in the Cloudflare DNS updater scripts so DNS records use valid addresses and respect parent script options.

Bug Fixes:
- Avoid selecting deprecated global IPv6 addresses for AAAA DNS records and skip updates when no valid address is available.
- Preserve DEBUG, FORCE, and SILENT flags passed from the parent script instead of unconditionally overriding them in the main script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Environment variables now override default application settings.
  * Added warning notifications when valid IPv6 addresses are unavailable.

* **Improvements**
  * Enhanced IPv6 address detection to exclude deprecated addresses.

* **Version Update**
  * Bumped to v1.1.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->