### PR TITLE
CF API refactor, add missing tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y shellcheck yamllint shfmt
+          curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | \
+            sudo bash -s -- latest /usr/bin
       - name: Run Validation Script
         run: |
           chmod +x tools/*.sh

--- a/cloudflare-dns-updater.sh
+++ b/cloudflare-dns-updater.sh
@@ -2,7 +2,7 @@
 
 # Resolve directory
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-# shellcheck source=../src/logger.sh
+# shellcheck source=src/logger.sh
 source "$DIR/src/logger.sh"
 CONFIG_FILE="$DIR/cloudflare-dns.yaml"
 

--- a/cloudflare-dns-updater.sh
+++ b/cloudflare-dns-updater.sh
@@ -2,6 +2,7 @@
 
 # Resolve directory
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=../src/logger.sh
 source "$DIR/src/logger.sh"
 CONFIG_FILE="$DIR/cloudflare-dns.yaml"
 

--- a/src/cloudflare.sh
+++ b/src/cloudflare.sh
@@ -4,9 +4,8 @@ CF_API_URL="https://api.cloudflare.com/client/v4"
 
 # Fetch all records (optional filter by type)
 cf_get_all_records() {
-	local type=$1
-	local url="$CF_API_URL/zones/$CF_ZONE_ID/dns_records?per_page=500"
-	[[ -n "$type" ]] && url="${url}&type=${type}"
+	local type="$1"
+	local url="$CF_API_URL/zones/$CF_ZONE_ID/dns_records?per_page=5000000&match=any&type=$type"
 
 	log_debug "API: GET $url"
 

--- a/src/cloudflare.sh
+++ b/src/cloudflare.sh
@@ -5,7 +5,7 @@ CF_API_URL="https://api.cloudflare.com/client/v4"
 # Fetch all records (optional filter by type)
 cf_get_all_records() {
 	local type="$1"
-	local url="$CF_API_URL/zones/$CF_ZONE_ID/dns_records?per_page=500"
+	local url="$CF_API_URL/zones/$CF_ZONE_ID/dns_records?per_page=5000"
 	[[ -n "$type" ]] && url="${url}&type=${type}"
 
 	log_debug "API: GET $url"

--- a/src/cloudflare.sh
+++ b/src/cloudflare.sh
@@ -5,7 +5,8 @@ CF_API_URL="https://api.cloudflare.com/client/v4"
 # Fetch all records (optional filter by type)
 cf_get_all_records() {
 	local type="$1"
-	local url="$CF_API_URL/zones/$CF_ZONE_ID/dns_records?per_page=5000000&match=any&type=$type"
+	local url="$CF_API_URL/zones/$CF_ZONE_ID/dns_records?per_page=500"
+	[[ -n "$type" ]] && url="${url}&type=${type}"
 
 	log_debug "API: GET $url"
 
@@ -46,8 +47,8 @@ cf_parse_records_to_lines() {
 	# Parse
 	if [[ -n "$jq_cmd" ]]; then
 		log_debug "Using JSON parser: $jq_cmd"
-		# Filter for A and AAAA records only
-		echo "$json" | "$jq_cmd" -r '.result[] | select(.type == "A" or .type == "AAAA") | "\(.id)|\(.name)|\(.type)|\(.content)|\(.proxied)"'
+
+		echo "$json" | "$jq_cmd" -r '.result[] | "\(.id)|\(.name)|\(.type)|\(.content)|\(.proxied)"'
 	else
 		log_warn "jq not found. Using sed parser fallback."
 
@@ -62,11 +63,8 @@ cf_parse_records_to_lines() {
 				content=$(echo "$line" | grep -o '"content":"[^"]*"' | head -n1 | cut -d'"' -f4)
 				proxied=$(echo "$line" | grep -o '"proxied":[^,}]*' | head -n1 | cut -d':' -f2 | tr -d ' ')
 
-				# Local filter for A and AAAA
-				if [[ "$type" == "A" || "$type" == "AAAA" ]]; then
-					if [[ -n "$id" && -n "$name" ]]; then
-						echo "$id|$name|$type|$content|$proxied"
-					fi
+				if [[ -n "$id" && -n "$name" ]]; then
+					echo "$id|$name|$type|$content|$proxied"
 				fi
 			done
 	fi

--- a/src/main.sh
+++ b/src/main.sh
@@ -148,7 +148,7 @@ main() {
 	log_info "Fetching DNS records from Cloudflare..."
 	local fetch_type="A,AAAA"
 
-	# Logic: If we only need one type
+	# Logic: If we only need one type, filter at API level
 	if [[ $total_v4 -gt 0 && $total_v6 -eq 0 ]]; then
 		fetch_type="A"
 	elif [[ $total_v4 -eq 0 && $total_v6 -gt 0 ]]; then

--- a/src/main.sh
+++ b/src/main.sh
@@ -146,8 +146,9 @@ main() {
 
 	# 3. Fetch Cloudflare Records (Single Request)
 	log_info "Fetching DNS records from Cloudflare..."
-	local fetch_type="A%2CAAAA"
+	local fetch_type="A,AAAA"
 
+	# Logic: If we only need one type
 	if [[ $total_v4 -gt 0 && $total_v6 -eq 0 ]]; then
 		fetch_type="A"
 	elif [[ $total_v4 -eq 0 && $total_v6 -gt 0 ]]; then

--- a/src/main.sh
+++ b/src/main.sh
@@ -146,7 +146,7 @@ main() {
 
 	# 3. Fetch Cloudflare Records (Single Request)
 	log_info "Fetching DNS records from Cloudflare..."
-	local fetch_type=""
+	local fetch_type="A%2CAAAA"
 
 	# Logic: If we only need one type, filter at API level.
 	# If we need both, fetch all in 1 call to minimize RTT.

--- a/src/main.sh
+++ b/src/main.sh
@@ -148,8 +148,6 @@ main() {
 	log_info "Fetching DNS records from Cloudflare..."
 	local fetch_type="A%2CAAAA"
 
-	# Logic: If we only need one type, filter at API level.
-	# If we need both, fetch all in 1 call to minimize RTT.
 	if [[ $total_v4 -gt 0 && $total_v6 -eq 0 ]]; then
 		fetch_type="A"
 	elif [[ $total_v4 -eq 0 && $total_v6 -gt 0 ]]; then


### PR DESCRIPTION
Filter only A or AAAA DNS records (when type is not set), 
increase per_page value

## Summary by Sourcery

Increase Cloudflare DNS record fetch limits and constrain retrieval to A and AAAA records by default to reduce unnecessary data.

Bug Fixes:
- Restrict Cloudflare DNS record retrieval to A and AAAA records when a specific type is not requested to avoid fetching irrelevant records.

Enhancements:
- Raise the Cloudflare DNS records per_page limit to support retrieving a much larger set of records in a single API call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * DNS fetching now requests A and AAAA types together by default, reducing API calls and improving retrieval speed.
  * Increased default page size for record queries to better handle large datasets.
  * Record parsing now returns all DNS record types so more records are surfaced.

* **Chores**
  * Added static-analysis guidance comments with no runtime impact.
  * CI updated to install an additional linting tool.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmrplens/Cloudflare-DNS-Updater/pull/111)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->