### PR TITLE
ci: fix yamllint and shellcheck issues in auto-assign workflow

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,3 +1,4 @@
+---
 name: Auto-assign
 
 on:
@@ -13,8 +14,12 @@ jobs:
       issues: write
       pull-requests: write
     if: >-
-      (github.event_name == 'issues' && github.event.issue.user.login != 'jmrplens' && github.event.issue.user.login != 'dependabot[bot]') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'jmrplens' && github.event.pull_request.user.login != 'dependabot[bot]')
+      (github.event_name == 'issues' &&
+       github.event.issue.user.login != 'jmrplens' &&
+       github.event.issue.user.login != 'dependabot[bot]') ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.user.login != 'jmrplens' &&
+       github.event.pull_request.user.login != 'dependabot[bot]')
     steps:
       - name: Assign to jmrplens
         env:
@@ -25,5 +30,5 @@ jobs:
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
-            /repos/$REPO/issues/$NUMBER/assignees \
+            "/repos/$REPO/issues/$NUMBER/assignees" \
             -f assignees[]=jmrplens


### PR DESCRIPTION
## Summary
The `auto-assign.yml` workflow (added in #113–#115) fails the repo's own validation suite, which has kept the **Lint & Validation** workflow red on `main` since it landed:

- **yamllint**: missing `---` document start, two lines over 120 characters, no newline at end of file.
- **actionlint (shellcheck SC2086)**: unquoted `$REPO`/`$NUMBER` in the `gh api` path.

This PR reformats the `if:` condition across multiple lines (folded scalar, semantics unchanged) and quotes the API path. Verified locally: `yamllint` and `actionlint -shellcheck=shellcheck` both pass, and `./tools/validate.sh` is green again.

Intentionally does **not** touch `lint.yml` to avoid conflicting with #111; pinning the actionlint install added there will come in a follow-up PR.

## Test plan
- [x] `yamllint .github/workflows/auto-assign.yml` passes
- [x] `actionlint -shellcheck=shellcheck` passes
- [ ] Lint & Validation workflow green on this PR

https://claude.ai/code/session_013Jk5mu56BzYTqRpwWf6fZB

## Summary by Sourcery

Fix CI lint failures in the auto-assign GitHub Actions workflow by making it compliant with yamllint and shellcheck.

Bug Fixes:
- Resolve yamllint errors in the auto-assign workflow by adding a YAML document start and adjusting formatting.
- Fix shellcheck/actionlint issues in the auto-assign workflow by quoting the GitHub API path variables.

Enhancements:
- Reformat the auto-assign workflow condition for improved readability while preserving behavior.

Build:
- Restore passing status of the Lint & Validation workflow on main by fixing validation issues in auto-assign.yml.