### PR TITLE
fix: harden Cloudflare API layer (pagination, defensive filter, timeouts)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,8 +20,16 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y shellcheck yamllint shfmt
-          curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | \
-            sudo bash -s -- latest /usr/bin
+      - name: Install actionlint (pinned, checksum-verified)
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/actionlint.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "$ACTIONLINT_SHA256  $RUNNER_TEMP/actionlint.tar.gz" | sha256sum -c -
+          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$RUNNER_TEMP" actionlint
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
       - name: Run Validation Script
         run: |
           chmod +x tools/*.sh

--- a/src/cloudflare.sh
+++ b/src/cloudflare.sh
@@ -18,6 +18,7 @@ cf_get_all_records() {
 	local page=1
 	local total_pages=1
 	local combined=""
+	local response=""
 
 	while true; do
 		local url="${base_url}&page=${page}"
@@ -42,7 +43,10 @@ cf_get_all_records() {
 		fi
 
 		# total_pages extracted with grep so pagination also works without jq
-		total_pages=$(echo "$response" | grep -o '"total_pages":[0-9]*' | head -n1 | cut -d':' -f2)
+		# (whitespace-tolerant in case the JSON is ever pretty-printed)
+		total_pages=$(echo "$response" |
+			grep -o '"total_pages"[[:space:]]*:[[:space:]]*[0-9]*' |
+			head -n1 | grep -o '[0-9]*$' || true)
 		total_pages=${total_pages:-1}
 
 		if [[ $page -ge $total_pages ]]; then
@@ -82,6 +86,8 @@ cf_parse_records_to_lines() {
 		echo "$json" | "$jq_cmd" -r '.result[] | select(.type == "A" or .type == "AAAA") | "\(.id)|\(.name)|\(.type)|\(.content)|\(.proxied)"'
 	else
 		log_warn "jq not found. Using sed parser fallback."
+
+		local line id name type content proxied
 
 		# The first sed keeps the opening quote of the next record's "id"
 		# key in the replacement; dropping it silently discards every

--- a/src/cloudflare.sh
+++ b/src/cloudflare.sh
@@ -2,27 +2,56 @@
 
 CF_API_URL="https://api.cloudflare.com/client/v4"
 
-# Fetch all records (optional filter by type)
+# Fetch all records (optional filter by type), following pagination.
+# NOTE: "type" accepts a comma-separated list (e.g. "A,AAAA"). This is
+# undocumented Cloudflare API behavior (the public schema models a single
+# enum value); it has been verified against the live API, and
+# cf_parse_records_to_lines keeps a defensive local A/AAAA filter in case
+# it ever changes.
+# Output: one JSON response document per page (newline-separated); both
+# the jq and sed parsers in cf_parse_records_to_lines handle the stream.
 cf_get_all_records() {
 	local type="$1"
-	local url="$CF_API_URL/zones/$CF_ZONE_ID/dns_records?per_page=5000"
-	[[ -n "$type" ]] && url="${url}&type=${type}"
+	local base_url="$CF_API_URL/zones/$CF_ZONE_ID/dns_records?per_page=5000"
+	[[ -n "$type" ]] && base_url="${base_url}&type=${type}"
 
-	log_debug "API: GET $url"
+	local page=1
+	local total_pages=1
+	local combined=""
 
-	response=$(http_request "GET" "$url" "" \
-		"Authorization: Bearer $CF_API_TOKEN" \
-		"Content-Type: application/json")
+	while true; do
+		local url="${base_url}&page=${page}"
+		log_debug_redacted "API: GET $url"
 
-	log_debug_redacted "API Response: $response"
+		response=$(http_request "GET" "$url" "" \
+			"Authorization: Bearer $CF_API_TOKEN" \
+			"Content-Type: application/json")
 
-	if [[ "$response" != *"\"success\":true"* ]]; then
-		log_error "Failed to fetch records"
-		log_debug_redacted "$response"
-		return 1
-	fi
+		log_debug_redacted "API Response: $response"
 
-	echo "$response"
+		if [[ "$response" != *"\"success\":true"* ]]; then
+			log_error "Failed to fetch records (page $page)"
+			log_debug_redacted "$response"
+			return 1
+		fi
+
+		if [[ -n "$combined" ]]; then
+			combined+=$'\n'"$response"
+		else
+			combined="$response"
+		fi
+
+		# total_pages extracted with grep so pagination also works without jq
+		total_pages=$(echo "$response" | grep -o '"total_pages":[0-9]*' | head -n1 | cut -d':' -f2)
+		total_pages=${total_pages:-1}
+
+		if [[ $page -ge $total_pages ]]; then
+			break
+		fi
+		page=$((page + 1))
+	done
+
+	echo "$combined"
 }
 
 # Parse JSON response into flat readable lines:
@@ -44,16 +73,21 @@ cf_parse_records_to_lines() {
 		jq_cmd=""
 	fi
 
-	# Parse
+	# Parse. Only A and AAAA records are emitted: the API request already
+	# filters by type, but that relies on undocumented multi-type support
+	# (see cf_get_all_records), so keep a defensive local filter too.
 	if [[ -n "$jq_cmd" ]]; then
 		log_debug "Using JSON parser: $jq_cmd"
 
-		echo "$json" | "$jq_cmd" -r '.result[] | "\(.id)|\(.name)|\(.type)|\(.content)|\(.proxied)"'
+		echo "$json" | "$jq_cmd" -r '.result[] | select(.type == "A" or .type == "AAAA") | "\(.id)|\(.name)|\(.type)|\(.content)|\(.proxied)"'
 	else
 		log_warn "jq not found. Using sed parser fallback."
 
+		# The first sed keeps the opening quote of the next record's "id"
+		# key in the replacement; dropping it silently discards every
+		# record after the first one.
 		echo "$json" |
-			sed -e 's/},{"/}\n{/g' |
+			sed -e 's/},{"/}\n{"/g' |
 			sed -e 's/\[{/{/g' |
 			sed -e 's/}\]//g' |
 			while read -r line; do
@@ -63,8 +97,10 @@ cf_parse_records_to_lines() {
 				content=$(echo "$line" | grep -o '"content":"[^"]*"' | head -n1 | cut -d'"' -f4)
 				proxied=$(echo "$line" | grep -o '"proxied":[^,}]*' | head -n1 | cut -d':' -f2 | tr -d ' ')
 
-				if [[ -n "$id" && -n "$name" ]]; then
-					echo "$id|$name|$type|$content|$proxied"
+				if [[ "$type" == "A" || "$type" == "AAAA" ]]; then
+					if [[ -n "$id" && -n "$name" ]]; then
+						echo "$id|$name|$type|$content|$proxied"
+					fi
 				fi
 			done
 	fi

--- a/src/main.sh
+++ b/src/main.sh
@@ -162,8 +162,14 @@ main() {
 
 	parsed_records=$(cf_parse_records_to_lines "$raw_records")
 	local record_lines
-	record_lines=$(echo "$parsed_records" | grep -c "^" || echo 0)
-	log_info "Parsed $record_lines records from Cloudflare (processing $DOMAIN_COUNT domains)." # 4. Analyze Records
+	# printf (no trailing newline) so an empty result counts 0, not 1
+	record_lines=$(printf '%s' "$parsed_records" | grep -c .)
+	log_info "Parsed $record_lines records from Cloudflare (processing $DOMAIN_COUNT domains)."
+	if [[ "$record_lines" -eq 0 ]]; then
+		log_warn "No A/AAAA records returned by Cloudflare for this zone."
+	fi
+
+	# 4. Analyze Records
 	log_info "Analyzing records..."
 
 	for ((i = 0; i < DOMAIN_COUNT; i++)); do

--- a/src/main.sh
+++ b/src/main.sh
@@ -162,8 +162,9 @@ main() {
 
 	parsed_records=$(cf_parse_records_to_lines "$raw_records")
 	local record_lines
-	# printf (no trailing newline) so an empty result counts 0, not 1
-	record_lines=$(printf '%s' "$parsed_records" | grep -c .)
+	# printf (no trailing newline) so an empty result counts 0, not 1;
+	# '|| true' because grep -c exits 1 on zero matches (set -e safety)
+	record_lines=$(printf '%s' "$parsed_records" | grep -c . || true)
 	log_info "Parsed $record_lines records from Cloudflare (processing $DOMAIN_COUNT domains)."
 	if [[ "$record_lines" -eq 0 ]]; then
 		log_warn "No A/AAAA records returned by Cloudflare for this zone."

--- a/src/network.sh
+++ b/src/network.sh
@@ -36,8 +36,9 @@ http_request() {
 	fi
 
 	if [[ "$HTTP_CLIENT" == "curl" || "$HTTP_CLIENT" == "curl.exe" ]]; then
-		# Build curl command array
-		local cmd=("$HTTP_CLIENT" "-s" "-X" "$method")
+		# Build curl command array. Timeouts keep a hung API from blocking
+		# the whole run (this script usually runs unattended via cron).
+		local cmd=("$HTTP_CLIENT" "-s" "--connect-timeout" "10" "--max-time" "30" "-X" "$method")
 
 		# Add headers
 		for h in "${headers[@]}"; do

--- a/tests/cloudflare_test.sh
+++ b/tests/cloudflare_test.sh
@@ -92,6 +92,12 @@ function test_parse_records_jq_extracts_wildcard_record() {
 	assert_contains "rec-a-wildcard|*.example.com|A|192.0.2.10|false" "$parsed"
 }
 
+function test_parse_records_jq_filters_out_other_types() {
+	local parsed
+	parsed=$(cf_parse_records_to_lines "$(cat "$FIXTURES/dns_records.json")")
+	assert_not_contains "rec-txt-root" "$parsed"
+}
+
 # --- cf_parse_records_to_lines (sed fallback path, no jq in PATH) ---
 
 function test_parse_records_sed_fallback_extracts_records() {
@@ -111,11 +117,10 @@ function test_parse_records_sed_fallback_extracts_records() {
 	' 2>/dev/null)
 	rm -rf "$shim"
 
-	# NOTE: the sed fallback currently only extracts the first record of a
-	# response: the '},{"' split eats the opening quote of the next record's
-	# "id" key, so every later record is dropped. Tracked for a fix; this
-	# test documents today's behavior.
 	assert_contains "rec-a-root|example.com|A|192.0.2.10|true" "$parsed"
+	assert_contains "rec-aaaa-root|example.com|AAAA|2001:db8::10|true" "$parsed"
+	assert_contains "rec-a-wildcard|*.example.com|A|192.0.2.10|false" "$parsed"
+	assert_not_contains "rec-txt-root" "$parsed"
 }
 
 # --- cf_get_all_records ---
@@ -139,6 +144,24 @@ function test_get_all_records_returns_response_on_success() {
 function test_get_all_records_fails_on_api_error() {
 	bashunit::mock http_request fake_http_request_failure
 	assert_general_error "$(cf_get_all_records "A,AAAA" 2>/dev/null)"
+}
+
+function fake_http_request_paginated() {
+	local url="$2"
+	if [[ "$url" == *"page=1"* ]]; then
+		echo '{"result":[{"id":"page1-rec","name":"p1.example.com","type":"A","content":"192.0.2.1","proxied":true,"ttl":1}],"result_info":{"page":1,"per_page":5000,"count":1,"total_count":2,"total_pages":2},"success":true,"errors":[]}'
+	else
+		echo '{"result":[{"id":"page2-rec","name":"p2.example.com","type":"AAAA","content":"2001:db8::2","proxied":false,"ttl":1}],"result_info":{"page":2,"per_page":5000,"count":1,"total_count":2,"total_pages":2},"success":true,"errors":[]}'
+	fi
+}
+
+function test_get_all_records_follows_pagination() {
+	bashunit::mock http_request fake_http_request_paginated
+	local response parsed
+	response=$(cf_get_all_records "A,AAAA")
+	parsed=$(cf_parse_records_to_lines "$response")
+	assert_contains "page1-rec|p1.example.com|A|192.0.2.1|true" "$parsed"
+	assert_contains "page2-rec|p2.example.com|AAAA|2001:db8::2|false" "$parsed"
 }
 
 # --- cf_batch_update ---

--- a/tests/network_test.sh
+++ b/tests/network_test.sh
@@ -18,7 +18,8 @@ function test_http_request_get_builds_curl_command() {
 	http_request "GET" "https://api.example.com/records" "" \
 		"Authorization: Bearer tok" >/dev/null
 	assert_have_been_called_with curl \
-		-s -X GET -H "Authorization: Bearer tok" "https://api.example.com/records"
+		-s --connect-timeout 10 --max-time 30 -X GET \
+		-H "Authorization: Bearer tok" "https://api.example.com/records"
 }
 
 function test_http_request_post_includes_body() {
@@ -26,7 +27,8 @@ function test_http_request_post_includes_body() {
 	http_request "POST" "https://api.example.com/batch" '{"puts":[]}' \
 		"Authorization: Bearer tok" "Content-Type: application/json" >/dev/null
 	assert_have_been_called_with curl \
-		-s -X POST -H "Authorization: Bearer tok" -H "Content-Type: application/json" \
+		-s --connect-timeout 10 --max-time 30 -X POST \
+		-H "Authorization: Bearer tok" -H "Content-Type: application/json" \
 		-d '{"puts":[]}' "https://api.example.com/batch"
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #111, closing its two open review points, plus bugs surfaced by the new test suite (#117):

- **Defensive A/AAAA filter restored** in `cf_parse_records_to_lines` (jq and sed paths). The API-level `type=A,AAAA` filter is undocumented Cloudflare behavior — verified live, but the public schema models a single enum — so the parser no longer trusts callers to pre-filter. The assumption is documented at the call site.
- **Real pagination** in `cf_get_all_records` via `result_info.total_pages` (extracted with grep, so it works without jq too). Zones with >5000 records are no longer silently truncated.
- **sed fallback parser fixed**: the `},{\"` split ate the opening quote of the next record's `"id"` key, so jq-less systems only ever extracted the **first** record of every response.
- **Timeouts** (`--connect-timeout 10 --max-time 30`) on API calls in `http_request`; a hung API could previously block the (typically cron-driven) run forever.
- Empty parse results now log `0` records (not 1) and warn.
- Zone ID redacted in the request-URL debug log line.
- **actionlint pinned** in CI to 1.7.12 with SHA-256 verification instead of piping an unpinned script into `sudo bash` (the other #111 review point).

## Test plan
- [x] 66 unit tests green locally (2 new: pagination across mocked pages, multi-record sed parsing; strengthened: type-filter exclusion assertions)
- [x] Live end-to-end run against the real zone (34 domains, 77 records): correct parse, "No changes needed"
- [ ] CI green on this PR

https://claude.ai/code/session_013Jk5mu56BzYTqRpwWf6fZB

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/Cloudflare-DNS-Updater/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

