### PR TITLE
fix: config parser, locking, notifications and misc bugs

### DIFF
--- a/cloudflare-dns-updater.sh
+++ b/cloudflare-dns-updater.sh
@@ -25,13 +25,14 @@ fi
 
 if command -v flock >/dev/null 2>&1; then
 	# Atomic lock: held for the lifetime of this process, released by the
-	# kernel on exit (no stale-lock or check-then-write races).
-	exec 200>"$LOCKFILE"
+	# kernel on exit (no stale-lock or check-then-write races). Open in
+	# append mode so a losing instance never truncates the holder's PID.
+	exec 200>>"$LOCKFILE"
 	if ! flock -n 200; then
 		echo "Script is already running (lock: $LOCKFILE). Exiting."
 		exit 1
 	fi
-	echo $$ >&200
+	printf '%s\n' $$ >"$LOCKFILE" # informational: PID of the lock holder
 else
 	# Portable fallback: PID file with staleness check
 	if [[ -f "$LOCKFILE" ]]; then

--- a/cloudflare-dns-updater.sh
+++ b/cloudflare-dns-updater.sh
@@ -95,10 +95,11 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
 	exit 1
 fi
 
-# The config contains the API token: warn if other users can read it
+# The config contains the API token: warn if group/others can read it
+# (octal mask 0044 = the group and other read bits)
 if ! is_silent; then
 	CONFIG_PERMS=$(stat -c '%a' "$CONFIG_FILE" 2>/dev/null || stat -f '%Lp' "$CONFIG_FILE" 2>/dev/null)
-	if [[ -n "$CONFIG_PERMS" && "$CONFIG_PERMS" != *00 ]]; then
+	if [[ "$CONFIG_PERMS" =~ ^[0-7]+$ ]] && ((8#$CONFIG_PERMS & 8#0044)); then
 		echo "Warning: $CONFIG_FILE is readable by other users (mode $CONFIG_PERMS)." >&2
 		echo "It contains your API token; consider: chmod 600 $CONFIG_FILE" >&2
 	fi

--- a/cloudflare-dns-updater.sh
+++ b/cloudflare-dns-updater.sh
@@ -9,6 +9,13 @@ CONFIG_FILE="$DIR/cloudflare-dns.yaml"
 # Ensure tools are found by adding standard paths (including Windows/MSYS2)
 export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/c/msys64/mingw64/bin:/mnt/c/msys64/mingw64/bin:$PATH"
 
+# Help does not need the lock or a config file
+for arg in "$@"; do
+	if [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
+		exec "$DIR/src/main.sh" --help
+	fi
+done
+
 # --- LOCK MECHANISM ---
 LOCKFILE="/tmp/cloudflare-dns-updater.lock"
 # Fallback if /tmp is not available
@@ -16,21 +23,30 @@ if [[ ! -d "/tmp" ]]; then
 	LOCKFILE="$DIR/cloudflare-dns-updater.lock"
 fi
 
-if [[ -f "$LOCKFILE" ]]; then
-	PID=$(cat "$LOCKFILE")
-	if ps -p "$PID" >/dev/null 2>&1; then
-		echo "Script is already running (PID: $PID). Exiting."
+if command -v flock >/dev/null 2>&1; then
+	# Atomic lock: held for the lifetime of this process, released by the
+	# kernel on exit (no stale-lock or check-then-write races).
+	exec 200>"$LOCKFILE"
+	if ! flock -n 200; then
+		echo "Script is already running (lock: $LOCKFILE). Exiting."
 		exit 1
-	else
-		echo "Found stale lock file (PID: $PID). Overwriting."
 	fi
+	echo $$ >&200
+else
+	# Portable fallback: PID file with staleness check
+	if [[ -f "$LOCKFILE" ]]; then
+		PID=$(cat "$LOCKFILE")
+		if ps -p "$PID" >/dev/null 2>&1; then
+			echo "Script is already running (PID: $PID). Exiting."
+			exit 1
+		else
+			echo "Found stale lock file (PID: $PID). Overwriting."
+		fi
+	fi
+
+	echo $$ >"$LOCKFILE"
+	trap 'rm -f "$LOCKFILE"' EXIT
 fi
-
-# Write PID
-echo $$ >"$LOCKFILE"
-
-# Cleanup on exit
-trap 'rm -f "$LOCKFILE"' EXIT
 # ----------------------
 
 # Parse Arguments
@@ -76,6 +92,15 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
 	fi
 	echo "Configuration file not found!"
 	exit 1
+fi
+
+# The config contains the API token: warn if other users can read it
+if ! is_silent; then
+	CONFIG_PERMS=$(stat -c '%a' "$CONFIG_FILE" 2>/dev/null || stat -f '%Lp' "$CONFIG_FILE" 2>/dev/null)
+	if [[ -n "$CONFIG_PERMS" && "$CONFIG_PERMS" != *00 ]]; then
+		echo "Warning: $CONFIG_FILE is readable by other users (mode $CONFIG_PERMS)." >&2
+		echo "It contains your API token; consider: chmod 600 $CONFIG_FILE" >&2
+	fi
 fi
 
 "$DIR/src/main.sh" "$CONFIG_FILE"

--- a/src/config.sh
+++ b/src/config.sh
@@ -10,6 +10,10 @@ TG_CHAT_ID=""
 DISCORD_ENABLED="false"
 DISCORD_WEBHOOK=""
 
+# Global domain defaults (options: block)
+DEFAULT_PROXIED="true"
+DEFAULT_TTL="auto"
+
 # Domain arrays
 domains_names=()
 domains_proxied=()
@@ -17,6 +21,26 @@ domains_ipv4=()
 domains_ipv6=()
 domains_ttl=()
 DOMAIN_COUNT=0
+
+# Normalize a raw YAML scalar: strip trailing CR (CRLF configs), inline
+# comments, surrounding whitespace and quotes.
+clean_value() {
+	local val="$1"
+	val="${val%%$'\r'*}"
+	val=$(echo "$val" | sed 's/[[:space:]]#.*$//;s/^[[:space:]]*//;s/[[:space:]]*$//')
+	val="${val%\"}"
+	val="${val#\"}"
+	val="${val%\'}"
+	val="${val#\'}"
+	echo "$val"
+}
+
+# Extract "key: value" from a block of lines (first match)
+_yaml_get() {
+	local block="$1"
+	local key="$2"
+	clean_value "$(echo "$block" | grep "$key:" | head -n1 | awk -F': ' '{print $2}')"
+}
 
 # Parse YAML config file
 parse_config() {
@@ -33,18 +57,30 @@ parse_config() {
 	fi
 
 	# Parse Global Settings
-	CF_ZONE_ID=$(grep "zone_id:" "$yaml_file" | head -n1 | awk -F': ' '{print $2}' | tr -d ' "')
-	CF_API_TOKEN=$(grep "api_token:" "$yaml_file" | head -n1 | awk -F': ' '{print $2}' | tr -d ' "')
+	CF_ZONE_ID=$(_yaml_get "$(cat "$yaml_file")" "zone_id")
+	CF_API_TOKEN=$(_yaml_get "$(cat "$yaml_file")" "api_token")
 
-	# Parse Options
-	NET_INTERFACE=$(grep "interface:" "$yaml_file" | head -n1 | awk -F': ' '{print $2}' | tr -d ' "')
+	# Parse Options (global domain defaults)
+	local options_block
+	options_block=$(grep -A 5 "^options:" "$yaml_file")
+	NET_INTERFACE=$(_yaml_get "$options_block" "interface")
+	DEFAULT_PROXIED=$(_yaml_get "$options_block" "proxied")
+	DEFAULT_PROXIED=${DEFAULT_PROXIED:-true}
+	DEFAULT_TTL=$(_yaml_get "$options_block" "ttl")
+	DEFAULT_TTL=${DEFAULT_TTL:-auto}
+	# Cloudflare uses ttl=1 for "auto"
+	[[ "$DEFAULT_TTL" == "1" ]] && DEFAULT_TTL="auto"
 
-	TG_ENABLED=$(grep -A 5 "telegram:" "$yaml_file" | grep "enabled:" | head -n1 | awk -F': ' '{print $2}' | tr -d ' "')
-	TG_BOT_TOKEN=$(grep -A 5 "telegram:" "$yaml_file" | grep "bot_token:" | head -n1 | awk -F': ' '{print $2}' | tr -d ' "')
-	TG_CHAT_ID=$(grep -A 5 "telegram:" "$yaml_file" | grep "chat_id:" | head -n1 | awk -F': ' '{print $2}' | tr -d ' "')
+	# Parse Notifications
+	local tg_block discord_block
+	tg_block=$(grep -A 5 "telegram:" "$yaml_file")
+	TG_ENABLED=$(_yaml_get "$tg_block" "enabled")
+	TG_BOT_TOKEN=$(_yaml_get "$tg_block" "bot_token")
+	TG_CHAT_ID=$(_yaml_get "$tg_block" "chat_id")
 
-	DISCORD_ENABLED=$(grep -A 5 "discord:" "$yaml_file" | grep "enabled:" | head -n1 | awk -F': ' '{print $2}' | tr -d ' "')
-	DISCORD_WEBHOOK=$(grep -A 5 "discord:" "$yaml_file" | grep "webhook_url:" | head -n1 | awk -F': ' '{print $2}' | tr -d ' "')
+	discord_block=$(grep -A 5 "discord:" "$yaml_file")
+	DISCORD_ENABLED=$(_yaml_get "$discord_block" "enabled")
+	DISCORD_WEBHOOK=$(_yaml_get "$discord_block" "webhook_url")
 
 	export CF_ZONE_ID CF_API_TOKEN NET_INTERFACE TG_ENABLED TG_BOT_TOKEN TG_CHAT_ID DISCORD_ENABLED DISCORD_WEBHOOK
 
@@ -60,6 +96,7 @@ parse_config() {
 
 	while IFS= read -r line || [[ -n "$line" ]]; do
 		clean_line=$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+		clean_line="${clean_line%$'\r'}"
 
 		# skip comments and empty lines
 		if [[ "$clean_line" =~ ^# ]] || [[ -z "$clean_line" ]]; then
@@ -71,7 +108,9 @@ parse_config() {
 			continue
 		fi
 
-		if [[ "$clean_line" == "settings:" ]]; then
+		# Any other top-level key (unindented, ends with ':') closes the
+		# domains block, not just a specific hardcoded section name.
+		if [[ "$in_domains_block" == "true" && "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*:[[:space:]]*$ ]]; then
 			in_domains_block=false
 		fi
 
@@ -79,26 +118,25 @@ parse_config() {
 			# New domain entry
 			if [[ "$line" =~ -[[:space:]]name:[[:space:]]*(.*) ]]; then
 				current_idx=$((current_idx + 1))
-				val="${BASH_REMATCH[1]}"
-				domains_names[current_idx]="${val//\"/}" # remove quotes
+				domains_names[current_idx]=$(clean_value "${BASH_REMATCH[1]}")
 
-				# Set defaults
-				domains_proxied[current_idx]="true"
+				# Set defaults (inherited from the options: block)
+				domains_proxied[current_idx]="$DEFAULT_PROXIED"
 				domains_ipv4[current_idx]="true"
 				domains_ipv6[current_idx]="true"
-				domains_ttl[current_idx]="auto"
+				domains_ttl[current_idx]="$DEFAULT_TTL"
 			fi
 
 			# Parse properties
 			if [[ $current_idx -ge 0 ]]; then
 				if [[ "$clean_line" =~ ^proxied:[[:space:]]*(.*) ]]; then
-					domains_proxied[current_idx]="${BASH_REMATCH[1]}"
+					domains_proxied[current_idx]=$(clean_value "${BASH_REMATCH[1]}")
 				elif [[ "$clean_line" =~ ^ipv4:[[:space:]]*(.*) ]]; then
-					domains_ipv4[current_idx]="${BASH_REMATCH[1]}"
+					domains_ipv4[current_idx]=$(clean_value "${BASH_REMATCH[1]}")
 				elif [[ "$clean_line" =~ ^ipv6:[[:space:]]*(.*) ]]; then
-					domains_ipv6[current_idx]="${BASH_REMATCH[1]}"
+					domains_ipv6[current_idx]=$(clean_value "${BASH_REMATCH[1]}")
 				elif [[ "$clean_line" =~ ^ip_type:[[:space:]]*(.*) ]]; then
-					val="${BASH_REMATCH[1]}"
+					val=$(clean_value "${BASH_REMATCH[1]}")
 					if [[ "$val" == "ipv4" ]]; then
 						domains_ipv4[current_idx]="true"
 						domains_ipv6[current_idx]="false"
@@ -110,7 +148,7 @@ parse_config() {
 						domains_ipv6[current_idx]="true"
 					fi
 				elif [[ "$clean_line" =~ ^ttl:[[:space:]]*(.*) ]]; then
-					domains_ttl[current_idx]="${BASH_REMATCH[1]}"
+					domains_ttl[current_idx]=$(clean_value "${BASH_REMATCH[1]}")
 				fi
 			fi
 		fi

--- a/src/config.sh
+++ b/src/config.sh
@@ -27,19 +27,22 @@ DOMAIN_COUNT=0
 clean_value() {
 	local val="$1"
 	val="${val%%$'\r'*}"
-	val=$(echo "$val" | sed 's/[[:space:]]#.*$//;s/^[[:space:]]*//;s/[[:space:]]*$//')
+	val=$(printf '%s' "$val" | sed 's/[[:space:]]#.*$//;s/^[[:space:]]*//;s/[[:space:]]*$//')
 	val="${val%\"}"
 	val="${val#\"}"
 	val="${val%\'}"
 	val="${val#\'}"
-	echo "$val"
+	printf '%s\n' "$val"
 }
 
-# Extract "key: value" from a block of lines (first match)
+# Extract "key: value" from a block of lines (first match). The key is
+# anchored to the start of the line so commented-out keys and keys that
+# merely end with the same text (e.g. my_ttl vs ttl) never match, and the
+# value keeps any colons it contains.
 _yaml_get() {
 	local block="$1"
 	local key="$2"
-	clean_value "$(echo "$block" | grep "$key:" | head -n1 | awk -F': ' '{print $2}')"
+	clean_value "$(printf '%s\n' "$block" | sed -n "s/^[[:space:]]*$key:[[:space:]]*//p" | head -n1)"
 }
 
 # Parse YAML config file
@@ -108,9 +111,9 @@ parse_config() {
 			continue
 		fi
 
-		# Any other top-level key (unindented, ends with ':') closes the
-		# domains block, not just a specific hardcoded section name.
-		if [[ "$in_domains_block" == "true" && "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*:[[:space:]]*$ ]]; then
+		# Any other top-level key (unindented, with or without an inline
+		# value) closes the domains block, not just a hardcoded name.
+		if [[ "$in_domains_block" == "true" && "$line" =~ ^[A-Za-z_][A-Za-z0-9_-]*: ]]; then
 			in_domains_block=false
 		fi
 

--- a/src/ip.sh
+++ b/src/ip.sh
@@ -183,6 +183,10 @@ is_valid_ipv6() {
 	[[ "$ip" =~ ^[0-9a-fA-F:]+$ ]] || return 1
 	[[ "$ip" == *":"* ]] || return 1
 	[[ "$ip" == *"::"*"::"* ]] && return 1
+	[[ "$ip" == *":::"* ]] && return 1
+	# A single colon at either edge is invalid; '::' there is fine
+	[[ "$ip" == :* && "$ip" != ::* ]] && return 1
+	[[ "$ip" == *: && "$ip" != *:: ]] && return 1
 
 	# Count non-empty groups (read -ra drops trailing empty fields, so
 	# counting array elements would wrongly accept e.g. 1:2:3:4:5:6:7:8::)

--- a/src/ip.sh
+++ b/src/ip.sh
@@ -177,23 +177,29 @@ is_valid_ipv4() {
 }
 
 # Structural validation: hex+colons only, at most one '::', hextets of at
-# most 4 chars, and exactly 8 groups when there is no '::'.
+# most 4 chars, exactly 8 groups without '::' and at most 7 with it.
 is_valid_ipv6() {
 	local ip="$1"
 	[[ "$ip" =~ ^[0-9a-fA-F:]+$ ]] || return 1
 	[[ "$ip" == *":"* ]] || return 1
 	[[ "$ip" == *"::"*"::"* ]] && return 1
 
+	# Count non-empty groups (read -ra drops trailing empty fields, so
+	# counting array elements would wrongly accept e.g. 1:2:3:4:5:6:7:8::)
 	local -a parts
 	IFS=':' read -ra parts <<<"$ip"
-	((${#parts[@]} <= 8)) || return 1
-	local part
+	local part groups=0
 	for part in "${parts[@]}"; do
 		((${#part} <= 4)) || return 1
+		if [[ -n "$part" ]]; then
+			groups=$((groups + 1))
+		fi
 	done
 
-	if [[ "$ip" != *"::"* ]]; then
-		((${#parts[@]} == 8)) || return 1
+	if [[ "$ip" == *"::"* ]]; then
+		((groups <= 7)) || return 1
+	else
+		((groups == 8)) || return 1
 	fi
 	return 0
 }

--- a/src/ip.sh
+++ b/src/ip.sh
@@ -168,11 +168,34 @@ get_ipv6_from_interface() {
 
 # IP Validation Helpers
 is_valid_ipv4() {
-	[[ "$1" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]
+	[[ "$1" =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]] || return 1
+	local octet
+	for octet in "${BASH_REMATCH[@]:1:4}"; do
+		# 10# forces base-10 so leading zeros are not read as octal
+		((10#$octet <= 255)) || return 1
+	done
 }
 
+# Structural validation: hex+colons only, at most one '::', hextets of at
+# most 4 chars, and exactly 8 groups when there is no '::'.
 is_valid_ipv6() {
-	[[ "$1" =~ ^[0-9a-fA-F:]+$ ]] && [[ "$1" == *":"* ]]
+	local ip="$1"
+	[[ "$ip" =~ ^[0-9a-fA-F:]+$ ]] || return 1
+	[[ "$ip" == *":"* ]] || return 1
+	[[ "$ip" == *"::"*"::"* ]] && return 1
+
+	local -a parts
+	IFS=':' read -ra parts <<<"$ip"
+	((${#parts[@]} <= 8)) || return 1
+	local part
+	for part in "${parts[@]}"; do
+		((${#part} <= 4)) || return 1
+	done
+
+	if [[ "$ip" != *"::"* ]]; then
+		((${#parts[@]} == 8)) || return 1
+	fi
+	return 0
 }
 
 # Get Public IPv4

--- a/src/main.sh
+++ b/src/main.sh
@@ -132,7 +132,8 @@ main() {
 	done
 	log_success "Loaded $DOMAIN_COUNT domains (Tasks: $total_v4 IPv4, $total_v6 IPv6)."
 
-	# 2. Get Current Public IPs	log_info "Detecting Public IPs..."
+	# 2. Get Current Public IPs
+	log_info "Detecting Public IPs..."
 	CURRENT_IPV4=$(get_public_ipv4)
 	CURRENT_IPV6=$(get_public_ipv6)
 

--- a/src/network.sh
+++ b/src/network.sh
@@ -120,7 +120,7 @@ http_get() {
 
 	# Build as an array so an unset ip_flag adds no argument at all
 	# (a quoted empty string would reach curl/wget as a bogus "" URL).
-	local cmd
+	local -a cmd
 	if [[ "$HTTP_CLIENT" == "curl" || "$HTTP_CLIENT" == "curl.exe" ]]; then
 		cmd=("$HTTP_CLIENT" "-s")
 		[[ -n "$ip_flag" ]] && cmd+=("$ip_flag")

--- a/src/network.sh
+++ b/src/network.sh
@@ -118,10 +118,19 @@ http_get() {
 		elif [[ "$HTTP_CLIENT" == "wget" ]]; then ip_flag="-6"; fi
 	fi
 
+	# Build as an array so an unset ip_flag adds no argument at all
+	# (a quoted empty string would reach curl/wget as a bogus "" URL).
+	local cmd
 	if [[ "$HTTP_CLIENT" == "curl" || "$HTTP_CLIENT" == "curl.exe" ]]; then
-		$HTTP_CLIENT -s "$ip_flag" --max-time 10 "$url"
+		cmd=("$HTTP_CLIENT" "-s")
+		[[ -n "$ip_flag" ]] && cmd+=("$ip_flag")
+		cmd+=("--max-time" "10" "$url")
+		"${cmd[@]}"
 	elif [[ "$HTTP_CLIENT" == "wget" ]]; then
-		wget -q -O - "$ip_flag" --timeout=10 --tries=1 "$url"
+		cmd=("wget" "-q" "-O" "-")
+		[[ -n "$ip_flag" ]] && cmd+=("$ip_flag")
+		cmd+=("--timeout=10" "--tries=1" "$url")
+		"${cmd[@]}"
 	elif [[ "$HTTP_CLIENT" == "powershell" ]]; then
 		# PowerShell doesn't have a simple flag for -4/-6 in Invoke-RestMethod easily for all versions
 		# but usually it respects the OS preference.

--- a/src/notifications.sh
+++ b/src/notifications.sh
@@ -1,13 +1,40 @@
 #!/usr/bin/env bash
 
+# Percent-encode a string for use in an application/x-www-form-urlencoded body
+url_encode() {
+	local raw="$1"
+	local out=""
+	local i c
+	for ((i = 0; i < ${#raw}; i++)); do
+		c="${raw:i:1}"
+		case "$c" in
+		[a-zA-Z0-9.~_-]) out+="$c" ;;
+		*) out+=$(printf '%%%02X' "'$c") ;;
+		esac
+	done
+	echo "$out"
+}
+
+# Escape a string for embedding inside a JSON string literal
+json_escape() {
+	local raw="$1"
+	raw="${raw//\\/\\\\}"
+	raw="${raw//\"/\\\"}"
+	raw="${raw//$'\n'/\\n}"
+	raw="${raw//$'\r'/\\r}"
+	raw="${raw//$'\t'/\\t}"
+	echo "$raw"
+}
+
 send_notification() {
 	local message="$1"
+
+	local body
 
 	# Telegram
 	if [[ "$TG_ENABLED" == "true" ]]; then
 		if [[ -n "$TG_BOT_TOKEN" && -n "$TG_CHAT_ID" ]]; then
-			# Simple body construction (Telegram supports URL-encoded POST)
-			local body="chat_id=${TG_CHAT_ID}&text=${message}"
+			body="chat_id=${TG_CHAT_ID}&text=$(url_encode "$message")"
 			http_request "POST" "https://api.telegram.org/bot$TG_BOT_TOKEN/sendMessage" "$body" >/dev/null
 		fi
 	fi
@@ -15,7 +42,7 @@ send_notification() {
 	# Discord
 	if [[ "$DISCORD_ENABLED" == "true" ]]; then
 		if [[ -n "$DISCORD_WEBHOOK" ]]; then
-			local body="{\"content\": \"$message\"}"
+			body="{\"content\": \"$(json_escape "$message")\"}"
 			http_request "POST" "$DISCORD_WEBHOOK" "$body" "Content-Type: application/json" >/dev/null
 		fi
 	fi

--- a/src/notifications.sh
+++ b/src/notifications.sh
@@ -12,7 +12,7 @@ url_encode() {
 		*) out+=$(printf '%%%02X' "'$c") ;;
 		esac
 	done
-	echo "$out"
+	printf '%s\n' "$out"
 }
 
 # Escape a string for embedding inside a JSON string literal
@@ -23,7 +23,7 @@ json_escape() {
 	raw="${raw//$'\n'/\\n}"
 	raw="${raw//$'\r'/\\r}"
 	raw="${raw//$'\t'/\\t}"
-	echo "$raw"
+	printf '%s\n' "$raw"
 }
 
 send_notification() {

--- a/tests/bundle_test.sh
+++ b/tests/bundle_test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Tests for tools/bundle.sh output (monolith build)
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+PROJECT_ROOT="$TESTS_DIR/.."
+MONOLITH="$PROJECT_ROOT/dist/cloudflare-dns-updater-monolith.sh"
+
+function set_up_before_script() {
+	(cd "$PROJECT_ROOT" && ./tools/bundle.sh >/dev/null)
+}
+
+function test_monolith_has_valid_syntax() {
+	bash -n "$MONOLITH"
+	assert_successful_code
+}
+
+function test_monolith_lockfile_stores_real_pid() {
+	# A previous bug bundled 'echo $' (a literal dollar sign) instead of
+	# the PID, which broke the stale-lock detection in built binaries.
+	# shellcheck disable=SC2016 # asserting on literal source text
+	assert_contains 'echo $$ >"$LOCKFILE"' "$(cat "$MONOLITH")"
+}
+
+function test_monolith_uses_flock_when_available() {
+	assert_contains 'flock -n 200' "$(cat "$MONOLITH")"
+}
+
+function test_launcher_help_flag_works() {
+	assert_contains "Usage:" "$("$PROJECT_ROOT/cloudflare-dns-updater.sh" --help 2>/dev/null)"
+}

--- a/tests/config_test.sh
+++ b/tests/config_test.sh
@@ -78,6 +78,59 @@ function test_domain_overrides_proxied_and_ttl() {
 	assert_same "300" "${domains_ttl[3]}"
 }
 
+# --- Quoted values and inline comments ---
+
+function test_quoted_property_values_are_stripped() {
+	parse_config "$FIXTURES/quoted_config.yaml"
+	assert_same "quoted-zone" "$CF_ZONE_ID"
+	assert_same "quoted-token" "$CF_API_TOKEN"
+	assert_same "false" "${domains_proxied[0]}"
+	# quoted ip_type used to be silently ignored
+	assert_same "true" "${domains_ipv4[0]}"
+	assert_same "false" "${domains_ipv6[0]}"
+}
+
+function test_inline_comments_are_stripped_from_values() {
+	parse_config "$FIXTURES/quoted_config.yaml"
+	assert_same "120" "${domains_ttl[0]}"
+}
+
+# --- Global options defaults ---
+
+function test_domains_inherit_options_defaults() {
+	parse_config "$FIXTURES/options_config.yaml"
+	assert_same "false" "${domains_proxied[0]}"
+	assert_same "300" "${domains_ttl[0]}"
+}
+
+function test_domain_overrides_beat_options_defaults() {
+	parse_config "$FIXTURES/options_config.yaml"
+	assert_same "true" "${domains_proxied[1]}"
+	assert_same "60" "${domains_ttl[1]}"
+}
+
+function test_later_sections_do_not_leak_into_last_domain() {
+	parse_config "$FIXTURES/options_config.yaml"
+	# custom_section sets proxied: true / ttl: 999; the parser must have
+	# closed the domains block before reaching it.
+	assert_same "60" "${domains_ttl[1]}"
+	assert_same "2" "$DOMAIN_COUNT"
+}
+
+# --- CRLF (Windows line endings) ---
+
+function test_parses_crlf_config() {
+	local tmp
+	tmp=$(mktemp)
+	printf 'cloudflare:\r\n  zone_id: "crlf-zone"\r\n  api_token: "crlf-token"\r\n\r\ndomains:\r\n  - name: "crlf.example.com"\r\n    proxied: false\r\n' >"$tmp"
+	parse_config "$tmp"
+	assert_same "crlf-zone" "$CF_ZONE_ID"
+	assert_same "crlf-token" "$CF_API_TOKEN"
+	assert_same "crlf.example.com" "${domains_names[0]}"
+	assert_same "false" "${domains_proxied[0]}"
+	rm -f "$tmp"
+}
+
 # --- Error handling ---
 
 function test_missing_config_file_returns_error() {

--- a/tests/fixtures/options_config.yaml
+++ b/tests/fixtures/options_config.yaml
@@ -1,0 +1,25 @@
+---
+# Test fixture: global options defaults + domains block termination
+
+cloudflare:
+  zone_id: "opt-zone"
+  api_token: "opt-token"
+
+options:
+  proxied: false
+  ttl: 300
+
+domains:
+  # Inherits proxied=false and ttl=300 from options
+  - name: "inherit.example.com"
+
+  # Overrides both
+  - name: "override.example.com"
+    proxied: true
+    ttl: 60
+
+# A later top-level section with domain-like keys must NOT leak into the
+# last domain (the parser must close the domains block here).
+custom_section:
+  proxied: true
+  ttl: 999

--- a/tests/fixtures/quoted_config.yaml
+++ b/tests/fixtures/quoted_config.yaml
@@ -1,0 +1,12 @@
+---
+# Test fixture: quoted scalars and inline comments must parse correctly
+
+cloudflare:
+  zone_id: "quoted-zone"
+  api_token: 'quoted-token'
+
+domains:
+  - name: "q.example.com"
+    ip_type: "ipv4"
+    proxied: "false"
+    ttl: 120 # two minutes

--- a/tests/ip_test.sh
+++ b/tests/ip_test.sh
@@ -67,6 +67,31 @@ function test_ipv6_rejects_words() {
 	assert_general_error "$(is_valid_ipv6 "not-an-ip")"
 }
 
+function test_ipv4_rejects_octets_over_255() {
+	assert_general_error "$(is_valid_ipv4 "999.999.999.999")"
+	assert_general_error "$(is_valid_ipv4 "256.0.0.1")"
+}
+
+function test_ipv4_accepts_leading_zero_octets() {
+	assert_successful_code "$(is_valid_ipv4 "010.001.002.099")"
+}
+
+function test_ipv6_accepts_full_eight_groups() {
+	assert_successful_code "$(is_valid_ipv6 "2a0c:5a84:b60e:8c00:7a55:36ff:fe04:bb9a")"
+}
+
+function test_ipv6_rejects_double_compression() {
+	assert_general_error "$(is_valid_ipv6 "2001::db8::1")"
+}
+
+function test_ipv6_rejects_oversized_hextet() {
+	assert_general_error "$(is_valid_ipv6 "12345::1")"
+}
+
+function test_ipv6_rejects_incomplete_address_without_compression() {
+	assert_general_error "$(is_valid_ipv6 "1:2:3:4:5:6:7")"
+}
+
 # --- get_public_ipv4 fallback cascade ---
 
 function fake_http_get_first_service_ok() {

--- a/tests/ip_test.sh
+++ b/tests/ip_test.sh
@@ -92,6 +92,15 @@ function test_ipv6_rejects_incomplete_address_without_compression() {
 	assert_general_error "$(is_valid_ipv6 "1:2:3:4:5:6:7")"
 }
 
+function test_ipv6_rejects_full_address_with_trailing_compression() {
+	assert_general_error "$(is_valid_ipv6 "1:2:3:4:5:6:7:8::")"
+}
+
+function test_ipv6_accepts_trailing_compression() {
+	assert_successful_code "$(is_valid_ipv6 "1:2:3:4:5:6:7::")"
+	assert_successful_code "$(is_valid_ipv6 "::1")"
+}
+
 # --- get_public_ipv4 fallback cascade ---
 
 function fake_http_get_first_service_ok() {

--- a/tests/ip_test.sh
+++ b/tests/ip_test.sh
@@ -99,6 +99,17 @@ function test_ipv6_rejects_full_address_with_trailing_compression() {
 function test_ipv6_accepts_trailing_compression() {
 	assert_successful_code "$(is_valid_ipv6 "1:2:3:4:5:6:7::")"
 	assert_successful_code "$(is_valid_ipv6 "::1")"
+	assert_successful_code "$(is_valid_ipv6 "::")"
+}
+
+function test_ipv6_rejects_triple_colon() {
+	assert_general_error "$(is_valid_ipv6 ":::")"
+	assert_general_error "$(is_valid_ipv6 "1:::2")"
+}
+
+function test_ipv6_rejects_single_edge_colons() {
+	assert_general_error "$(is_valid_ipv6 ":1:2:3:4:5:6:7:8")"
+	assert_general_error "$(is_valid_ipv6 "1:2:3:4:5:6:7:8:")"
 }
 
 # --- get_public_ipv4 fallback cascade ---

--- a/tests/network_test.sh
+++ b/tests/network_test.sh
@@ -50,3 +50,10 @@ function test_http_get_uses_ipv6_flag() {
 	http_get "https://icanhazip.com" 6 >/dev/null
 	assert_have_been_called_with curl -s -6 --max-time 10 "https://icanhazip.com"
 }
+
+function test_http_get_any_protocol_passes_no_empty_flag() {
+	bashunit::spy curl
+	http_get "https://icanhazip.com" >/dev/null
+	# No stray "" argument between -s and --max-time
+	assert_have_been_called_with curl -s --max-time 10 "https://icanhazip.com"
+}

--- a/tests/notifications_test.sh
+++ b/tests/notifications_test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Unit tests for src/notifications.sh
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+PROJECT_ROOT="$TESTS_DIR/.."
+
+function set_up() {
+	export DEBUG="false" SILENT="true" FORCE="false"
+	# shellcheck source=/dev/null
+	source "$PROJECT_ROOT/src/notifications.sh"
+}
+
+# --- Encoding helpers ---
+
+function test_url_encode_keeps_unreserved_characters() {
+	assert_same "abc-123_x.y~z" "$(url_encode "abc-123_x.y~z")"
+}
+
+function test_url_encode_encodes_spaces_and_symbols() {
+	assert_same "Updated%202%20records%20to%201.2.3.4" \
+		"$(url_encode "Updated 2 records to 1.2.3.4")"
+}
+
+function test_url_encode_encodes_ampersand_and_equals() {
+	assert_same "a%3Db%26c%3Dd" "$(url_encode "a=b&c=d")"
+}
+
+function test_json_escape_escapes_quotes() {
+	assert_same 'say \"hi\"' "$(json_escape 'say "hi"')"
+}
+
+function test_json_escape_escapes_backslashes_and_newlines() {
+	assert_same 'path\\to\nend' "$(json_escape $'path\\to\nend')"
+}
+
+# --- send_notification ---
+
+function test_telegram_notification_sends_encoded_body() {
+	TG_ENABLED="true" TG_BOT_TOKEN="bt" TG_CHAT_ID="42" DISCORD_ENABLED="false"
+	bashunit::spy http_request
+	send_notification "IP changed to 1.2.3.4"
+	assert_have_been_called_with http_request \
+		POST "https://api.telegram.org/botbt/sendMessage" \
+		"chat_id=42&text=IP%20changed%20to%201.2.3.4"
+}
+
+function test_discord_notification_escapes_json() {
+	TG_ENABLED="false" DISCORD_ENABLED="true" DISCORD_WEBHOOK="https://discord.example.invalid/wh"
+	bashunit::spy http_request
+	send_notification 'quote " inside'
+	assert_have_been_called_with http_request \
+		POST "https://discord.example.invalid/wh" \
+		'{"content": "quote \" inside"}' "Content-Type: application/json"
+}
+
+function test_no_notification_sent_when_disabled() {
+	TG_ENABLED="false" DISCORD_ENABLED="false"
+	bashunit::spy http_request
+	send_notification "nothing should happen"
+	assert_have_been_called_times 0 http_request
+}
+
+function test_telegram_skipped_without_credentials() {
+	TG_ENABLED="true" TG_BOT_TOKEN="" TG_CHAT_ID="" DISCORD_ENABLED="false"
+	bashunit::spy http_request
+	send_notification "no creds"
+	assert_have_been_called_times 0 http_request
+}

--- a/tools/bundle.sh
+++ b/tools/bundle.sh
@@ -157,27 +157,49 @@ if [[ ! -d "/tmp" ]]; then
 
 fi
 
-if [[ -f "$LOCKFILE" ]]; then
+if command -v flock >/dev/null 2>&1; then
 
-	PID=$(cat "$LOCKFILE")
+	# Atomic lock, released by the kernel on process exit
 
-	if ps -p "$PID" >/dev/null 2>&1; then
+	exec 200>"$LOCKFILE"
 
-		echo "Script is already running (PID: $PID). Exiting."
+	if ! flock -n 200; then
+
+		echo "Script is already running (lock: $LOCKFILE). Exiting."
 
 		exit 1
 
-	else
+	fi
 
-		echo "Found stale lock file (PID: $PID). Overwriting."
+	echo $$ >&200
+
+else
+
+	# Portable fallback: PID file with staleness check
+
+	if [[ -f "$LOCKFILE" ]]; then
+
+		PID=$(cat "$LOCKFILE")
+
+		if ps -p "$PID" >/dev/null 2>&1; then
+
+			echo "Script is already running (PID: $PID). Exiting."
+
+			exit 1
+
+		else
+
+			echo "Found stale lock file (PID: $PID). Overwriting."
+
+		fi
 
 	fi
 
+	echo $$ >"$LOCKFILE"
+
+	trap 'rm -f "$LOCKFILE"' EXIT
+
 fi
-
-echo $ >"$LOCKFILE"
-
-trap 'rm -f "$LOCKFILE"' EXIT
 
 # ----------------------
 

--- a/tools/bundle.sh
+++ b/tools/bundle.sh
@@ -159,9 +159,10 @@ fi
 
 if command -v flock >/dev/null 2>&1; then
 
-	# Atomic lock, released by the kernel on process exit
+	# Atomic lock, released by the kernel on process exit. Open in append
+	# mode so a losing instance never truncates the holder's PID.
 
-	exec 200>"$LOCKFILE"
+	exec 200>>"$LOCKFILE"
 
 	if ! flock -n 200; then
 
@@ -171,7 +172,7 @@ if command -v flock >/dev/null 2>&1; then
 
 	fi
 
-	echo $$ >&200
+	printf '%s\n' $$ >"$LOCKFILE"
 
 else
 


### PR DESCRIPTION
## Summary
The remaining fixes from the project review, each covered by new unit tests (28 new, 92 total).

**Config parser (`src/config.sh`)**
- Strip surrounding quotes, trailing CR (CRLF/Windows configs) and inline comments from all values (shared `clean_value` helper). Quoted values like `ip_type: "ipv4"` — which is exactly what `config.example.yaml` shows — were silently ignored before.
- `options.proxied` and `options.ttl` are now parsed as global domain defaults (documented in the README for a long time, never implemented).
- The `domains:` block now closes on any new top-level key instead of only the nonexistent `settings:`, so later sections can't leak properties into the last domain.

**Locking**
- `tools/bundle.sh` bundled `echo $` (a literal dollar sign) instead of `echo $$`, so the monolith and all built binaries wrote no PID and had **no working mutual exclusion**.
- Launcher and monolith wrapper now use `flock` when available (atomic, kernel-released, no TOCTOU); the PID-file staleness check remains as a portable fallback.

**Misc**
- `-h/--help` now works from the repo launcher.
- Startup warning when the config file (which holds the API token) is readable by group/others (suggests `chmod 600`).
- Restore the `log_info "Detecting Public IPs..."` line that had been absorbed into a comment.
- Strict IP validation: IPv4 octets ≤255 (base-10 safe), IPv6 structural checks (single `::`, ≤4-char hextets, 8 groups when uncompressed).
- `http_get` no longer passes an empty `""` argument to curl/wget when no IP protocol is forced.
- Telegram messages URL-encoded; Discord messages JSON-escaped.

## Test plan
- [x] 92 unit tests green (`./lib/bashunit --parallel tests/`), including new `notifications_test.sh` and `bundle_test.sh`
- [x] `./tools/validate.sh` fully green
- [x] Live run with the real production config (34 domains): parser produces identical results, permission warning fires on 644, `--help` works
- [ ] CI green on this PR

https://claude.ai/code/session_013Jk5mu56BzYTqRpwWf6fZB

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/Cloudflare-DNS-Updater/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

