### PR TITLE
ci: use Node 24 in the docs deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,8 @@ jobs:
         uses: withastro/action@v3
         with:
           path: ./docs
+          # pnpm 11 requires Node >= 22.13 (the action defaults to Node 20)
+          node-version: 24
           package-manager: pnpm@11.9.0
 
   deploy:


### PR DESCRIPTION
## Summary
The first **Deploy Docs** run failed: `withastro/action@v3` defaults to Node 20, but pnpm 11 requires Node ≥ 22.13 (`ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite` + explicit pnpm warning in the [failed run](https://github.com/jmrplens/Cloudflare-DNS-Updater/actions/runs/28756304011)). Pin `node-version: 24` (current LTS).

## Test plan
- [x] yamllint + actionlint green
- [ ] CI green on this PR
- [ ] After merge: Deploy Docs workflow publishes the site at https://jmrplens.github.io/Cloudflare-DNS-Updater/

https://claude.ai/code/session_013Jk5mu56BzYTqRpwWf6fZB

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/Cloudflare-DNS-Updater/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

