### PR TITLE
docs: show the menu button on the landing page

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -164,6 +164,9 @@ export default defineConfig({
 		starlight({
 			title: 'Cloudflare DNS Updater',
 			description: siteDescription,
+			// Enables the sidebar (and the mobile menu button) on the splash page
+			routeMiddleware: './src/routeData.ts',
+			customCss: ['./src/styles/custom.css'],
 			plugins: [
 				starlightLinksValidator({
 					errorOnRelativeLinks: false,

--- a/docs/src/routeData.ts
+++ b/docs/src/routeData.ts
@@ -1,0 +1,10 @@
+import { defineRouteMiddleware } from "@astrojs/starlight/route-data";
+
+// Starlight's splash template disables the sidebar, and with it the mobile
+// menu button — leaving phones with no way to navigate from the landing page.
+// Enable the sidebar everywhere; src/styles/custom.css keeps the desktop
+// splash layout full-width by hiding the sidebar pane on hero pages, so only
+// the mobile menu button (drawer) is gained.
+export const onRequest = defineRouteMiddleware((context) => {
+	context.locals.starlightRoute.hasSidebar = true;
+});

--- a/docs/src/routeData.ts
+++ b/docs/src/routeData.ts
@@ -1,10 +1,14 @@
-import { defineRouteMiddleware } from "@astrojs/starlight/route-data";
+import { defineRouteMiddleware } from '@astrojs/starlight/route-data';
 
 // Starlight's splash template disables the sidebar, and with it the mobile
 // menu button — leaving phones with no way to navigate from the landing page.
-// Enable the sidebar everywhere; src/styles/custom.css keeps the desktop
-// splash layout full-width by hiding the sidebar pane on hero pages, so only
-// the mobile menu button (drawer) is gained.
+// Re-enable the sidebar for splash pages only (other templates keep whatever
+// they configured); src/styles/custom.css keeps the desktop splash layout
+// full-width by hiding the sidebar pane on hero pages, so only the mobile
+// menu button (drawer) is gained.
 export const onRequest = defineRouteMiddleware((context) => {
-	context.locals.starlightRoute.hasSidebar = true;
+	const { starlightRoute } = context.locals;
+	if (starlightRoute.entry.data.template === 'splash') {
+		starlightRoute.hasSidebar = true;
+	}
 });

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -1,0 +1,15 @@
+/*
+ * The route middleware (src/routeData.ts) enables the sidebar on the splash
+ * landing page so the mobile menu button exists there. On desktop widths the
+ * hero should stay full-width, so hide the sidebar pane and reclaim the
+ * content offset on pages that render a hero. (Unlayered rules override
+ * Starlight's @layer starlight.core styles.)
+ */
+@media (min-width: 50em) {
+	[data-has-hero] .sidebar-pane {
+		display: none;
+	}
+	[data-has-hero] {
+		--sl-content-inline-start: 0;
+	}
+}

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -1,9 +1,12 @@
 /*
- * The route middleware (src/routeData.ts) enables the sidebar on the splash
- * landing page so the mobile menu button exists there. On desktop widths the
- * hero should stay full-width, so hide the sidebar pane and reclaim the
- * content offset on pages that render a hero. (Unlayered rules override
- * Starlight's @layer starlight.core styles.)
+ * The route middleware (src/routeData.ts) enables the sidebar on splash pages
+ * so the mobile menu button exists there. On desktop widths the hero should
+ * stay full-width, so hide the sidebar pane and reclaim the content offset on
+ * pages that render a hero. [data-has-hero] is the most specific hook
+ * Starlight exposes (there is no template attribute); in this site heroes
+ * only appear on the splash landing pages. Unlayered rules override
+ * Starlight's @layer starlight.core styles; 50em matches the breakpoint of
+ * the [data-has-sidebar] rule being reclaimed (Page.astro).
  */
 @media (min-width: 50em) {
 	[data-has-hero] .sidebar-pane {


### PR DESCRIPTION
## Summary
Starlight's `splash` template disables the sidebar, and with it the **mobile menu button** — so on phones the landing page offered no way into the docs beyond the hero buttons and search.

- `src/routeData.ts` (Starlight route middleware) sets `hasSidebar = true` on every page, which brings the menu button back on the splash.
- `src/styles/custom.css` hides the desktop sidebar pane on hero pages (`[data-has-hero]`, ≥50em) and reclaims `--sl-content-inline-start`, so the desktop hero stays exactly as it was — only mobile gains the drawer.

Verified in the browser (screenshots shared in session): menu button visible on the mobile splash, drawer opens with the full localized sidebar, desktop landing unchanged.

## Test plan
- [x] `pnpm build` clean (validator + i18n + llms + sitemap hooks all green)
- [x] Mobile 390px: button present on `/`, drawer opens with full nav
- [x] Desktop 1440px: hero full-width, no sidebar pane
- [ ] CI green on this PR

https://claude.ai/code/session_013Jk5mu56BzYTqRpwWf6fZB

## Summary by Sourcery

Ensure the docs landing page shows the mobile navigation drawer while keeping the desktop hero layout unchanged.

New Features:
- Enable the Starlight sidebar and mobile menu button on the documentation splash page.

Enhancements:
- Configure Starlight route middleware and custom CSS to selectively show the sidebar drawer on mobile while hiding the sidebar pane on desktop hero pages.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/Cloudflare-DNS-Updater/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

