### PR TITLE
docs: link Wikidata item, submit to IndexNow after deploys, ignore .env

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,6 +55,8 @@ jobs:
     name: Submit to IndexNow
     needs: deploy
     runs-on: ubuntu-latest
+    # Best-effort ping: a failure here must never mark a successful deploy red
+    continue-on-error: true
     steps:
       - name: Notify IndexNow of updated URLs
         env:
@@ -69,7 +71,10 @@ jobs:
           # Use the actual deployed Pages URL (tracks a custom domain / CNAME and
           # any repo/org rename automatically).
           BASE="${PAGE_URL%/}"
-          if [ -z "$BASE" ]; then echo "No deploy page_url available; aborting"; exit 1; fi
+          if [ -z "$BASE" ]; then
+            echo "::warning title=IndexNow::no deploy page_url available (non-fatal); skipping"
+            exit 0
+          fi
           HOST="$(printf '%s' "$BASE" | sed -E 's#^https?://([^/]+).*#\1#')"
           echo "Site base: $BASE (host: $HOST)"
           # Fetch the live sitemap with a short retry/backoff for deploy propagation.
@@ -83,17 +88,22 @@ jobs:
             echo "::warning title=IndexNow::could not fetch sitemap after retries (non-fatal); skipping"
             exit 0
           fi
-          # Collect sub-sitemap URLs, then each sitemap's <loc> entries. A while
-          # loop over a here-string (not a pipe) keeps errors from being masked
-          # under `set -o pipefail`; a transient sub-sitemap fetch can't abort all.
-          subs=$(printf '%s' "$idx" | grep -oE '<loc>[^<]+</loc>' | sed -E 's#</?loc>##g')
+          # Collect sub-sitemap URLs, then each sitemap's <loc> entries. Every
+          # extraction carries '|| true': under `set -euo pipefail` a grep with
+          # zero matches exits 1 and would abort the whole best-effort job.
+          subs=$(printf '%s' "$idx" | grep -oE '<loc>[^<]+</loc>' | sed -E 's#</?loc>##g' || true)
           urls=""
           while IFS= read -r sm; do
             [ -n "$sm" ] || continue
             body=$(curl -fsSL "$sm" || true)
-            urls="${urls}$(printf '%s' "$body" | grep -oE '<loc>[^<]+</loc>' | sed -E 's#</?loc>##g')"$'\n'
+            urls="${urls}$(printf '%s' "$body" | grep -oE '<loc>[^<]+</loc>' | sed -E 's#</?loc>##g' || true)"$'\n'
           done <<< "$subs"
-          url_json=$(printf '%s\n' "$urls" | grep . | jq -R . | jq -s .)
+          urls_clean=$(printf '%s\n' "$urls" | grep . || true)
+          if [ -z "$urls_clean" ]; then
+            echo "::warning title=IndexNow::no URLs extracted from the sitemap (non-fatal); skipping"
+            exit 0
+          fi
+          url_json=$(printf '%s\n' "$urls_clean" | jq -R . | jq -s .)
           count=$(printf '%s' "$url_json" | jq 'length')
           echo "Submitting $count URLs to IndexNow"
           payload=$(jq -n \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,77 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v5
+
+  indexnow:
+    name: Submit to IndexNow
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify IndexNow of updated URLs
+        env:
+          INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }}
+          PAGE_URL: ${{ needs.deploy.outputs.page_url }}
+        run: |
+          set -euo pipefail
+          if [ -z "${INDEXNOW_KEY:-}" ]; then
+            echo "INDEXNOW_KEY not set — skipping IndexNow submission"
+            exit 0
+          fi
+          # Use the actual deployed Pages URL (tracks a custom domain / CNAME and
+          # any repo/org rename automatically).
+          BASE="${PAGE_URL%/}"
+          if [ -z "$BASE" ]; then echo "No deploy page_url available; aborting"; exit 1; fi
+          HOST="$(printf '%s' "$BASE" | sed -E 's#^https?://([^/]+).*#\1#')"
+          echo "Site base: $BASE (host: $HOST)"
+          # Fetch the live sitemap with a short retry/backoff for deploy propagation.
+          idx=""
+          for attempt in 1 2 3 4 5; do
+            if idx=$(curl -fsSL "$BASE/sitemap-index.xml"); then break; fi
+            echo "sitemap fetch attempt ${attempt} failed; retrying in 10s…"
+            sleep 10
+          done
+          if [ -z "$idx" ]; then
+            echo "::warning title=IndexNow::could not fetch sitemap after retries (non-fatal); skipping"
+            exit 0
+          fi
+          # Collect sub-sitemap URLs, then each sitemap's <loc> entries. A while
+          # loop over a here-string (not a pipe) keeps errors from being masked
+          # under `set -o pipefail`; a transient sub-sitemap fetch can't abort all.
+          subs=$(printf '%s' "$idx" | grep -oE '<loc>[^<]+</loc>' | sed -E 's#</?loc>##g')
+          urls=""
+          while IFS= read -r sm; do
+            [ -n "$sm" ] || continue
+            body=$(curl -fsSL "$sm" || true)
+            urls="${urls}$(printf '%s' "$body" | grep -oE '<loc>[^<]+</loc>' | sed -E 's#</?loc>##g')"$'\n'
+          done <<< "$subs"
+          url_json=$(printf '%s\n' "$urls" | grep . | jq -R . | jq -s .)
+          count=$(printf '%s' "$url_json" | jq 'length')
+          echo "Submitting $count URLs to IndexNow"
+          payload=$(jq -n \
+            --arg host "$HOST" \
+            --arg key "$INDEXNOW_KEY" \
+            --arg keyLocation "https://${HOST}/${INDEXNOW_KEY}.txt" \
+            --argjson urlList "$url_json" \
+            '{host:$host, key:$key, keyLocation:$keyLocation, urlList:$urlList}')
+          # `|| true` so a transport error (DNS/timeout) can't abort under set -e;
+          # curl writes 000 to the http_code on failure, handled by the case below.
+          code=$(curl -sS -o /tmp/indexnow.out -w '%{http_code}' \
+            -X POST "https://api.indexnow.org/IndexNow" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$payload" || true)
+          echo "IndexNow responded HTTP $code"; cat /tmp/indexnow.out || true
+          # IndexNow is a best-effort ping — never fail the deploy over it.
+          # keyLocation points at the host ROOT (https://$HOST/<key>.txt) because
+          # IndexNow verifies ownership at the host level, and a GitHub Pages
+          # PROJECT site can't publish at the domain root. The key file is served
+          # from the ${GITHUB_REPOSITORY_OWNER}.github.io user-site repository.
+          case "$code" in
+            200|202) echo "IndexNow: submitted OK" ;;
+            *) echo "::warning title=IndexNow::submission returned HTTP $code (non-fatal)" ;;
+          esac

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Config
 cloudflare-dns.yaml
 
+# Local secrets (IndexNow key, Wikidata bot credentials)
+.env
+
 # Logs
 logs/
 *.log

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -141,6 +141,7 @@ const jsonLd = JSON.stringify({
 				priceCurrency: 'USD',
 			},
 			author: { '@id': authorId },
+			sameAs: ['https://www.wikidata.org/wiki/Q140447586'],
 		},
 		{
 			'@type': 'SoftwareSourceCode',


### PR DESCRIPTION
## Summary
Closes the discoverability loop pending from the SEO/GEO port (#125):

- **Wikidata**: the project now has its own item — [Q140447586](https://www.wikidata.org/wiki/Q140447586), created with the publishhelper bot mirroring gitlab-mcp-server's structure (free software + application, GNU Bash, MIT, Linux/macOS/Windows, dynamic-DNS use, Cloudflare + curl dependencies, inception date, all 6 released versions with 1.2.0 preferred). The `SoftwareApplication` node's `sameAs` now points at it, giving AI engines a knowledge-graph anchor.
- **IndexNow**: the docs workflow gains the `indexnow` job ported from `gitlab-mcp-server/pages.yml` — after each successful Pages deploy it submits every sitemap URL to `api.indexnow.org` (Bing et al.) using the `INDEXNOW_KEY` repo secret. The key file is already served from the user-site root (host-level verification, verified live). Best-effort by design: it never fails a deploy.
- **Secrets hygiene**: `.env` gitignored at the repo root; the same values are configured as Actions secrets (`INDEXNOW_KEY`, `WIKIDATA_BOT_USER`, `WIKIDATA_BOT_PASS`).

## Test plan
- [x] Wikidata item created and populated (Q140447586)
- [x] IndexNow key file verified live at the host root
- [x] `pnpm build` clean; `sameAs` present in the built @graph
- [x] yamllint + actionlint green on the workflow
- [ ] CI green on this PR
- [ ] After merge: indexnow job submits ~21 URLs with HTTP 200/202

https://claude.ai/code/session_013Jk5mu56BzYTqRpwWf6fZB

## Summary by Sourcery

Integrate IndexNow notifications into the docs deployment workflow and link the documentation’s software metadata to its Wikidata item, while tightening secrets handling.

New Features:
- Submit sitemap URLs to IndexNow after successful GitHub Pages docs deployments using the configured INDEXNOW_KEY secret.
- Expose the deployed docs Pages URL as a reusable workflow output for downstream jobs.

Enhancements:
- Add a Wikidata sameAs reference to the SoftwareApplication JSON-LD metadata in the docs configuration.
- Ignore root-level .env files to encourage using GitHub Actions secrets for sensitive configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated IndexNow submission after site deployment to help search engines discover updated pages faster.
  * Expanded site metadata with an additional public profile link.
* **Bug Fixes**
  * Made the deployment process more resilient by skipping IndexNow submission when required settings or sitemap access are unavailable.
* **Chores**
  * Updated ignore rules to keep local secret files out of version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->