### PR TITLE
docs: second round of GEO/SEO improvements

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -118,6 +118,7 @@ const jsonLd = JSON.stringify({
 				height: 512,
 			},
 			image: socialImage,
+			description: siteDescription,
 			founder: { '@id': authorId },
 			sameAs: [repositoryUrl, 'https://www.wikidata.org/wiki/Q140447586'],
 		},

--- a/docs/src/content/docs/automation.md
+++ b/docs/src/content/docs/automation.md
@@ -1,6 +1,12 @@
 ---
 title: Automation
 description: Run Cloudflare DNS Updater on a schedule with cron, systemd or Task Scheduler.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |-
+      {"@context":"https://schema.org","@type":"FAQPage","@id":"https://jmrplens.github.io/Cloudflare-DNS-Updater/automation/","inLanguage":"en","isPartOf":{"@id":"https://jmrplens.github.io/Cloudflare-DNS-Updater/#website"},"about":{"@id":"https://github.com/jmrplens/Cloudflare-DNS-Updater#software"},"mainEntity":[{"@type":"Question","name":"How often should it run?","acceptedAnswer":{"@type":"Answer","text":"Every 5 minutes is a comfortable default for home connections. Cloudflare's limit of 1200 requests per 5 minutes leaves large headroom even at one run per minute."}},{"@type":"Question","name":"Will overlapping runs cause problems?","acceptedAnswer":{"@type":"Answer","text":"No. A lockfile makes a second invocation exit immediately, so aggressive schedules are safe."}},{"@type":"Question","name":"How do I check it is working?","acceptedAnswer":{"@type":"Answer","text":"Run it once with --debug to watch IP detection and the API calls. When running from source, the same output is also written to logs/updater.log in the project directory."}},{"@type":"Question","name":"Does a run cost an API request when nothing changed?","acceptedAnswer":{"@type":"Answer","text":"Yes, one read request per run. It only writes to the API when the IP actually changed (or when you pass --force)."}}]}
 ---
 
 Dynamic IPs change without warning, so run the updater on a schedule. It exits quickly when nothing changed (one paginated API read, no writes), and the lock prevents overlapping runs.
@@ -67,3 +73,21 @@ systemctl list-timers cf-updater.timer
 ## Choosing an interval
 
 Every run that detects no change costs one read request to the Cloudflare API. Cloudflare's global API rate limit (1200 requests per 5 minutes per user) leaves enormous headroom even at one run per minute; every 5 minutes is a comfortable default for home connections.
+
+## Frequently asked questions
+
+### How often should it run?
+
+Every 5 minutes is a comfortable default for home connections. Cloudflare's limit of 1200 requests per 5 minutes leaves large headroom even at one run per minute.
+
+### Will overlapping runs cause problems?
+
+No. A lockfile makes a second invocation exit immediately, so aggressive schedules are safe.
+
+### How do I check it is working?
+
+Run it once with `--debug` to watch IP detection and the API calls. When running from source, the same output is also written to `logs/updater.log` in the project directory.
+
+### Does a run cost an API request when nothing changed?
+
+Yes, one read request per run. It only writes to the API when the IP actually changed (or when you pass `--force`).

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -1,6 +1,12 @@
 ---
 title: Configuration
 description: Complete reference for cloudflare-dns.yaml.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |-
+      {"@context":"https://schema.org","@type":"FAQPage","@id":"https://jmrplens.github.io/Cloudflare-DNS-Updater/configuration/","inLanguage":"en","isPartOf":{"@id":"https://jmrplens.github.io/Cloudflare-DNS-Updater/#website"},"about":{"@id":"https://github.com/jmrplens/Cloudflare-DNS-Updater#software"},"mainEntity":[{"@type":"Question","name":"What TTL should I use?","acceptedAnswer":{"@type":"Answer","text":"Leave ttl: 1 (Auto) for proxied records — Cloudflare ignores the TTL while a record is proxied. For DNS-only records, set a value in seconds (60–86400); a lower TTL propagates IP changes faster."}},{"@type":"Question","name":"What does proxied do?","acceptedAnswer":{"@type":"Answer","text":"proxied: true routes traffic through Cloudflare's proxy (orange cloud); proxied: false is DNS-only (grey cloud), which you want for direct connections such as SSH, game servers or mail."}},{"@type":"Question","name":"Can I update a wildcard record?","acceptedAnswer":{"@type":"Answer","text":"Yes. Use name: \"*.example.com\". Like any record, the wildcard must already exist in Cloudflare — the program updates records, it does not create them."}},{"@type":"Question","name":"Can I manage only IPv4 or only IPv6?","acceptedAnswer":{"@type":"Answer","text":"Yes. Each domain manages both A and AAAA by default; set ip_type: ipv4 or ip_type: ipv6 on a domain to limit it."}},{"@type":"Question","name":"Where does the config file need to be?","acceptedAnswer":{"@type":"Answer","text":"cloudflare-dns.yaml next to the launcher by default. Pass a path as an argument to use another location."}}]}
 ---
 
 The program reads a YAML file — `cloudflare-dns.yaml` by default — with four sections: `cloudflare`, `options`, `domains` and `notifications`.
@@ -86,3 +92,25 @@ See [Notifications](../notifications/) for setup guides.
 :::note[Zones with many records]
 Records are fetched 5000 per API call and pagination is followed automatically, so zones of any size work.
 :::
+
+## Frequently asked questions
+
+### What TTL should I use?
+
+Leave `ttl: 1` (Auto) for proxied records — Cloudflare ignores the TTL while a record is proxied. For DNS-only records, set a value in seconds (60–86400); a lower TTL propagates IP changes faster.
+
+### What does `proxied` do?
+
+`proxied: true` routes traffic through Cloudflare's proxy (orange cloud); `proxied: false` is DNS-only (grey cloud), which you want for direct connections such as SSH, game servers or mail.
+
+### Can I update a wildcard record?
+
+Yes. Use `name: "*.example.com"`. Like any record, the wildcard must already exist in Cloudflare — the program updates records, it does not create them.
+
+### Can I manage only IPv4 or only IPv6?
+
+Yes. Each domain manages both A and AAAA by default; set `ip_type: ipv4` or `ip_type: ipv6` on a domain to limit it.
+
+### Where does the config file need to be?
+
+`cloudflare-dns.yaml` next to the launcher by default. Pass a path as an argument to use another location.

--- a/docs/src/content/docs/es/automation.md
+++ b/docs/src/content/docs/es/automation.md
@@ -1,6 +1,12 @@
 ---
 title: Automatización
 description: Ejecuta Cloudflare DNS Updater periódicamente con cron, systemd o el Programador de tareas.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |-
+      {"@context":"https://schema.org","@type":"FAQPage","@id":"https://jmrplens.github.io/Cloudflare-DNS-Updater/es/automation/","inLanguage":"es","isPartOf":{"@id":"https://jmrplens.github.io/Cloudflare-DNS-Updater/#website"},"about":{"@id":"https://github.com/jmrplens/Cloudflare-DNS-Updater#software"},"mainEntity":[{"@type":"Question","name":"¿Con qué frecuencia debe ejecutarse?","acceptedAnswer":{"@type":"Answer","text":"Cada 5 minutos es un valor cómodo para conexiones domésticas. El límite de Cloudflare de 1200 peticiones por 5 minutos deja un margen amplio incluso ejecutando cada minuto."}},{"@type":"Question","name":"¿Las ejecuciones solapadas causan problemas?","acceptedAnswer":{"@type":"Answer","text":"No. Un lockfile hace que una segunda invocación salga de inmediato, así que los intervalos agresivos son seguros."}},{"@type":"Question","name":"¿Cómo compruebo que funciona?","acceptedAnswer":{"@type":"Answer","text":"Ejecútalo una vez con --debug para ver la detección de IP y las llamadas a la API. Al ejecutar desde el código fuente, la misma salida se escribe también en logs/updater.log dentro del directorio del proyecto."}},{"@type":"Question","name":"¿Una ejecución cuesta una petición a la API cuando no hay cambios?","acceptedAnswer":{"@type":"Answer","text":"Sí, una petición de lectura por ejecución. Solo escribe en la API cuando la IP ha cambiado realmente (o cuando pasas --force)."}}]}
 ---
 
 Las IP dinámicas cambian sin avisar, así que conviene ejecutar el actualizador periódicamente. Cuando no hay cambios termina enseguida (una lectura paginada de la API, ninguna escritura), y el lock evita ejecuciones solapadas.
@@ -67,3 +73,21 @@ systemctl list-timers cf-updater.timer
 ## Elegir el intervalo
 
 Cada ejecución sin cambios cuesta una petición de lectura a la API de Cloudflare. El límite global de la API (1200 peticiones por 5 minutos y usuario) deja un margen enorme incluso ejecutando cada minuto; cada 5 minutos es un valor cómodo para conexiones domésticas.
+
+## Preguntas frecuentes
+
+### ¿Con qué frecuencia debe ejecutarse?
+
+Cada 5 minutos es un valor cómodo para conexiones domésticas. El límite de Cloudflare de 1200 peticiones por 5 minutos deja un margen amplio incluso ejecutando cada minuto.
+
+### ¿Las ejecuciones solapadas causan problemas?
+
+No. Un lockfile hace que una segunda invocación salga de inmediato, así que los intervalos agresivos son seguros.
+
+### ¿Cómo compruebo que funciona?
+
+Ejecútalo una vez con `--debug` para ver la detección de IP y las llamadas a la API. Al ejecutar desde el código fuente, la misma salida se escribe también en `logs/updater.log` dentro del directorio del proyecto.
+
+### ¿Una ejecución cuesta una petición a la API cuando no hay cambios?
+
+Sí, una petición de lectura por ejecución. Solo escribe en la API cuando la IP ha cambiado realmente (o cuando pasas `--force`).

--- a/docs/src/content/docs/es/configuration.md
+++ b/docs/src/content/docs/es/configuration.md
@@ -1,6 +1,12 @@
 ---
 title: Configuración
 description: Referencia completa de cloudflare-dns.yaml.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |-
+      {"@context":"https://schema.org","@type":"FAQPage","@id":"https://jmrplens.github.io/Cloudflare-DNS-Updater/es/configuration/","inLanguage":"es","isPartOf":{"@id":"https://jmrplens.github.io/Cloudflare-DNS-Updater/#website"},"about":{"@id":"https://github.com/jmrplens/Cloudflare-DNS-Updater#software"},"mainEntity":[{"@type":"Question","name":"¿Qué TTL debo usar?","acceptedAnswer":{"@type":"Answer","text":"Deja ttl: 1 (Auto) para registros proxificados: Cloudflare ignora el TTL mientras un registro está proxificado. Para registros solo DNS, pon un valor en segundos (60–86400); un TTL más bajo propaga los cambios de IP más rápido."}},{"@type":"Question","name":"¿Qué hace proxied?","acceptedAnswer":{"@type":"Answer","text":"proxied: true enruta el tráfico por el proxy de Cloudflare (nube naranja); proxied: false es solo DNS (nube gris), que es lo que quieres para conexiones directas como SSH, servidores de juegos o correo."}},{"@type":"Question","name":"¿Puedo actualizar un registro comodín?","acceptedAnswer":{"@type":"Answer","text":"Sí. Usa name: \"*.example.com\". Como cualquier registro, el comodín debe existir ya en Cloudflare: el programa actualiza registros, no los crea."}},{"@type":"Question","name":"¿Puedo gestionar solo IPv4 o solo IPv6?","acceptedAnswer":{"@type":"Answer","text":"Sí. Cada dominio gestiona A y AAAA por defecto; pon ip_type: ipv4 o ip_type: ipv6 en un dominio para limitarlo."}},{"@type":"Question","name":"¿Dónde debe estar el fichero de configuración?","acceptedAnswer":{"@type":"Answer","text":"cloudflare-dns.yaml junto al lanzador por defecto. Pasa una ruta como argumento para usar otra ubicación."}}]}
 ---
 
 El programa lee un fichero YAML — `cloudflare-dns.yaml` por defecto — con cuatro secciones: `cloudflare`, `options`, `domains` y `notifications`.
@@ -86,3 +92,25 @@ Consulta [Notificaciones](../notifications/) para las guías de configuración.
 :::note[Zonas con muchos registros]
 Los registros se obtienen de 5000 en 5000 por llamada y la paginación se sigue automáticamente, así que funcionan zonas de cualquier tamaño.
 :::
+
+## Preguntas frecuentes
+
+### ¿Qué TTL debo usar?
+
+Deja `ttl: 1` (Auto) para registros proxificados: Cloudflare ignora el TTL mientras un registro está proxificado. Para registros solo DNS, pon un valor en segundos (60–86400); un TTL más bajo propaga los cambios de IP más rápido.
+
+### ¿Qué hace `proxied`?
+
+`proxied: true` enruta el tráfico por el proxy de Cloudflare (nube naranja); `proxied: false` es solo DNS (nube gris), que es lo que quieres para conexiones directas como SSH, servidores de juegos o correo.
+
+### ¿Puedo actualizar un registro comodín?
+
+Sí. Usa `name: "*.example.com"`. Como cualquier registro, el comodín debe existir ya en Cloudflare: el programa actualiza registros, no los crea.
+
+### ¿Puedo gestionar solo IPv4 o solo IPv6?
+
+Sí. Cada dominio gestiona A y AAAA por defecto; pon `ip_type: ipv4` o `ip_type: ipv6` en un dominio para limitarlo.
+
+### ¿Dónde debe estar el fichero de configuración?
+
+`cloudflare-dns.yaml` junto al lanzador por defecto. Pasa una ruta como argumento para usar otra ubicación.

--- a/docs/src/content/docs/es/getting-started.md
+++ b/docs/src/content/docs/es/getting-started.md
@@ -61,6 +61,21 @@ Consulta la [referencia de configuración](../configuration/) para ver todas las
 
 Con `--debug` verás cada paso: la detección de IP, las llamadas a la API y la decisión por registro. Cuando todo esté correcto, [prográmalo](../automation/) y añade `--silent` para un funcionamiento silencioso.
 
+## Cómo se compara
+
+Si ya mantienes tu DNS con un script propio de cron + curl, esto es lo que añade esta herramienta:
+
+| | Cloudflare DNS Updater | cron + curl manual |
+| --- | --- | --- |
+| Configuración | Un único fichero YAML | Escribir y mantener tu propio script |
+| IPv4 + IPv6 | Ambos; la IPv6 se lee de la interfaz local | Lo que implementes |
+| Varios registros | Agrupados en una sola llamada a la API | Una petición por registro |
+| Escribe solo si hay cambios | Sí | Normalmente en cada ejecución, salvo que añadas estado |
+| Notificaciones | Telegram y Discord | Ninguna |
+| Dependencias | Bash + jq opcional (los binarios incluyen ambos) | curl más tu propio código |
+
+Para un actualizador multiproveedor, [ddclient](https://github.com/ddclient/ddclient) es una alternativa común en Perl; esta herramienta se centra en Cloudflare con actualizaciones por lotes y detección de IPv6 desde la interfaz.
+
 ## Preguntas frecuentes
 
 ### ¿Cloudflare DNS Updater crea registros DNS?

--- a/docs/src/content/docs/es/index.mdx
+++ b/docs/src/content/docs/es/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: DNS dinámico para Cloudflare en Bash
-description: Actualizador de DNS dinámico para Cloudflare en Bash, con actualizaciones por lotes, detección IPv4/IPv6 y notificaciones.
+description: Actualizador DDNS de código abierto para Cloudflare en Bash — mantiene tus registros A y AAAA en tu IP pública actual con actualizaciones por lotes y detección de IPv6.
 template: splash
 hero:
   title: Cloudflare DNS Updater

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -61,6 +61,21 @@ See the [configuration reference](../configuration/) for every option.
 
 With `--debug` you see every step: IP detection, the API calls and the per-record decision. When everything looks right, [schedule it](../automation/) and add `--silent` for quiet operation.
 
+## How it compares
+
+If you already keep DNS updated with a hand-written cron + curl script, here is what this tool adds:
+
+| | Cloudflare DNS Updater | Manual cron + curl |
+| --- | --- | --- |
+| Setup | One YAML file | Write and maintain your own script |
+| IPv4 + IPv6 | Both; IPv6 read from the local interface | Whatever you implement |
+| Multiple records | Batched into a single API call | One request per record |
+| Writes only on change | Yes | Usually every run, unless you add state |
+| Notifications | Telegram and Discord | None |
+| Dependencies | Bash + optional jq (binaries bundle both) | curl plus your own glue |
+
+For a multi-provider updater, [ddclient](https://github.com/ddclient/ddclient) is a common Perl alternative; this tool focuses on Cloudflare with batched updates and IPv6-from-interface detection.
+
 ## Frequently asked questions
 
 ### Does Cloudflare DNS Updater create DNS records?

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dynamic DNS for Cloudflare in Bash
-description: A Bash-based dynamic DNS updater for Cloudflare with batch updates, IPv4/IPv6 detection and notifications.
+description: Open-source Bash dynamic DNS updater for Cloudflare — keeps your A and AAAA records pointed at your current public IP with batch API updates and IPv6 detection.
 template: splash
 hero:
   title: Cloudflare DNS Updater


### PR DESCRIPTION
Follow-up to #128 — applies the remaining **in-repo** items from the GEO re-audit. Off-site work (awesome-lists, Reddit/HN, YouTube, Wikipedia) is intentionally out of scope (not code).

## Changes
- **FAQ + FAQPage** on `/configuration/` and `/automation/` (EN + ES), `@id` = canonical page URL. Extends the question→answer pattern to the two main reference pages (lifts Google AI Overviews / ChatGPT / Gemini citability).
- **"How it compares" table** on getting-started (EN + ES): this tool vs a hand-written cron + curl script, plus a neutral pointer to `ddclient` as the multi-provider Perl alternative — a comparison block AI answer engines can cite. Claims are limited to verifiable facts.
- **Homepage meta description** expanded toward the 150–160 char SERP sweet spot (EN + ES).
- **Organization schema** enriched with a `description`.

## Verification
- `pnpm build` passes; i18n parity OK; all internal links valid.
- Every `ld+json` block parses — configuration/automation now carry graph + TechArticle + BreadcrumbList + **FAQPage** (4/4).
- Sitemap `lastmod` stamped for all 20 URLs.

## Deliberately skipped
- `SearchAction` — correctly N/A for Starlight's client-side Pagefind search.
- A 3rd Organization `sameAs` — no legitimate additional official profile exists; not manufactured.
- Wikidata `sameAs` on the software node — already present since #127.

https://claude.ai/code/session_01WF6ZSC4qFD84k5ZFVtoo1P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/Cloudflare-DNS-Updater/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

