### PR TITLE
docs: link the maintainer's Wikidata item in Person sameAs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -268,6 +268,7 @@ export default defineConfig({
 					},
 				},
 				{ tag: 'link', attrs: { rel: 'me', href: 'https://jmrp.io' } },
+				{ tag: 'link', attrs: { rel: 'me', href: 'https://www.wikidata.org/wiki/Q140455276' } },
 				// PGP public key
 				{
 					tag: 'link',

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -99,6 +99,7 @@ const jsonLd = JSON.stringify({
 				'https://orcid.org/0000-0003-1250-6212',
 				'https://www.researchgate.net/profile/Jose-Requena-Plens-2',
 				'https://www.mathworks.com/matlabcentral/profile/authors/5890853',
+				'https://www.wikidata.org/wiki/Q140455276',
 			],
 		},
 		{


### PR DESCRIPTION
Adds `https://www.wikidata.org/wiki/Q140455276` (the maintainer's Wikidata person item) to the Person node's `sameAs` in `astro.config.mjs`.

The site's software node already links to the project Wikidata item (Q140447586); this completes the author↔Wikidata link. The two items are cross-referenced on Wikidata (person P800 → project, project P178 → person).

Verified: `pnpm build` passes, i18n parity OK, internal links valid, homepage @graph parses, `Q140455276` present in built HTML.

Companion Wikidata edits made directly on Q140447586 this session: added P1401 (bug tracker), P407 (English + Spanish), P2283 (+jq), and P577 publication dates on all six P348 version statements.

https://claude.ai/code/session_01WF6ZSC4qFD84k5ZFVtoo1P

## Summary by Sourcery

Documentation:
- Document the maintainer's Wikidata identity by adding the corresponding item URL to the Person node's sameAs list in the site metadata.