### PR TITLE
docs: remove references to deleted Wikidata items

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -99,7 +99,6 @@ const jsonLd = JSON.stringify({
 				'https://orcid.org/0000-0003-1250-6212',
 				'https://www.researchgate.net/profile/Jose-Requena-Plens-2',
 				'https://www.mathworks.com/matlabcentral/profile/authors/5890853',
-				'https://www.wikidata.org/wiki/Q140455276',
 			],
 		},
 		{
@@ -121,7 +120,7 @@ const jsonLd = JSON.stringify({
 			image: socialImage,
 			description: siteDescription,
 			founder: { '@id': authorId },
-			sameAs: [repositoryUrl, 'https://www.wikidata.org/wiki/Q140447586'],
+			sameAs: [repositoryUrl],
 		},
 		{
 			'@type': 'WebSite',
@@ -164,7 +163,6 @@ const jsonLd = JSON.stringify({
 				priceCurrency: 'USD',
 			},
 			author: { '@id': authorId },
-			sameAs: ['https://www.wikidata.org/wiki/Q140447586'],
 		},
 		{
 			'@type': 'SoftwareSourceCode',
@@ -268,7 +266,6 @@ export default defineConfig({
 					},
 				},
 				{ tag: 'link', attrs: { rel: 'me', href: 'https://jmrp.io' } },
-				{ tag: 'link', attrs: { rel: 'me', href: 'https://www.wikidata.org/wiki/Q140455276' } },
 				// PGP public key
 				{
 					tag: 'link',


### PR DESCRIPTION
## Summary

The project (Q140447586) and personal (Q140455276) Wikidata items were deleted by a Wikidata admin on 2026-07-07 ("Mass deletion of pages added by Jmrplens", notability policy). Links to nonexistent entities are a negative entity-verification signal, so this removes the Person sameAs entry, the two project sameAs entries, and the `rel=me` head link from `docs/astro.config.mjs`.

Part of a cross-repo cleanup; companion PR jmrplens/gitlab-mcp-server#221.

https://claude.ai/code/session_016KQnnNLPVouuFYJqLd6kzv

## Summary by Sourcery

Remove references to deleted Wikidata entities from the documentation site metadata.

Documentation:
- Remove Person and Project Wikidata URLs from JSON-LD sameAs fields in the docs site configuration.
- Remove the Wikidata rel=me link from the docs HTML head configuration.