### PR TITLE
fix: clarify the warning for records missing in Cloudflare

### DIFF
--- a/docs/src/content/docs/es/troubleshooting.md
+++ b/docs/src/content/docs/es/troubleshooting.md
@@ -21,9 +21,11 @@ Otra instancia tiene el lock (`/tmp/cloudflare-dns-updater.lock`). Es normal con
 - La IPv6 se lee primero de una interfaz local. Si tu interfaz no tiene IPv6 global, se intenta la detección externa. Define `options.interface` explícitamente si la interfaz autodetectada no es la correcta.
 - ¿No tienes IPv6? Pon `ip_type: "ipv4"` en tus dominios para saltarte los registros AAAA.
 
-## «Record ... not found. Creation not implemented.»
+## «Record ... does not exist in Cloudflare»
 
 El programa solo **actualiza** registros existentes. Crea el registro A/AAAA una vez en el panel de Cloudflare (con cualquier IP; se corregirá en la siguiente ejecución) y vuelve a ejecutar.
+
+Si el nombre empieza por `*`, ten en cuenta que un comodín es el nombre literal de un registro, no un patrón que coincida con tus subdominios existentes. `*.example.com` solo funciona cuando existe un registro con ese nombre exacto en Cloudflare, y no afectará a `www.example.com` ni a ningún otro nombre que ya tenga su propio registro. Para mantener esos actualizados, ponlos uno a uno en `domains`.
 
 ## «Failed to fetch records» / «Batch update failed»
 

--- a/docs/src/content/docs/troubleshooting.md
+++ b/docs/src/content/docs/troubleshooting.md
@@ -21,9 +21,11 @@ Another instance holds the lock (`/tmp/cloudflare-dns-updater.lock`). Normal und
 - IPv6 is first read from a local interface. If your interface has no global IPv6, external detection is tried next. Set `options.interface` explicitly if the auto-detected interface is wrong.
 - No IPv6 at all? Set `ip_type: "ipv4"` on your domains so AAAA lookups are skipped.
 
-## "Record ... not found. Creation not implemented."
+## "Record ... does not exist in Cloudflare"
 
 The program only **updates** existing records. Create the A/AAAA record once in the Cloudflare dashboard (any IP, it will be corrected on the next run) and re-run.
+
+If the name starts with `*`, note that a wildcard is the literal name of a record, not a pattern that matches your existing subdomains. `*.example.com` only works once a record with that exact name exists in Cloudflare, and it will not affect `www.example.com` or any other name that already has its own record. To keep those updated, list them individually in `domains`.
 
 ## "Failed to fetch records" / "Batch update failed"
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -81,7 +81,12 @@ queue_if_changed() {
 	match=$(cf_get_record_from_cache "$parsed_records" "$domain" "$type")
 
 	if [[ -z "$match" ]]; then
-		log_warn "Record $type for $domain not found. Creation not implemented."
+		log_warn "Record $type for $domain does not exist in Cloudflare. Create it once in the dashboard (any IP); this program only updates existing records."
+		# A wildcard name is a literal record, not a filter over existing
+		# subdomains: the most common misreading of the warning above.
+		if [[ "$domain" == \** ]]; then
+			log_warn "  Note: '$domain' is the name of a wildcard record, not a pattern matching your existing subdomains. List those by name to keep them updated."
+		fi
 		return
 	fi
 

--- a/tests/main_test.sh
+++ b/tests/main_test.sh
@@ -35,6 +35,29 @@ function test_queue_skips_unknown_record() {
 	assert_same "0" "$update_count"
 }
 
+function test_queue_warns_that_missing_record_must_be_created_first() {
+	local out
+	SILENT="false"
+	out=$(queue_if_changed "A" "missing.example.com" "192.0.2.9" "true" "auto" 2>&1)
+	assert_contains "does not exist in Cloudflare" "$out"
+	assert_contains "only updates existing records" "$out"
+}
+
+function test_queue_explains_wildcard_semantics_for_missing_wildcard() {
+	local out
+	SILENT="false"
+	out=$(queue_if_changed "A" "*.example.com" "192.0.2.9" "true" "auto" 2>&1)
+	assert_contains "does not exist in Cloudflare" "$out"
+	assert_contains "not a pattern" "$out"
+}
+
+function test_queue_does_not_mention_wildcards_for_regular_names() {
+	local out
+	SILENT="false"
+	out=$(queue_if_changed "A" "missing.example.com" "192.0.2.9" "true" "auto" 2>&1)
+	assert_not_contains "not a pattern" "$out"
+}
+
 function test_queue_skips_when_record_matches() {
 	queue_if_changed "A" "home.example.com" "192.0.2.1" "true" "auto"
 	assert_same "0" "$update_count"


### PR DESCRIPTION
## Why

Issue #133 reported "wildcard updates don't work". The tool behaved correctly, but the warning it printed was actively unhelpful:

```
[WARN] Record A for *.eidemiller.org not found. Creation not implemented.
```

"Creation not implemented" reads like a half-finished feature and says nothing about what the user should do. It dates back to a pre-1.0 TODO comment (`c97e421` removed the comment, kept the wording).

## What changed

`src/main.sh`: the warning now states the actual condition and the fix.

```
[WARN] Record A for plain.example.com does not exist in Cloudflare. Create it once in the dashboard (any IP); this program only updates existing records.
```

Wildcard names get a second line, because that is the misreading behind #133:

```
[WARN] Record A for *.example.com does not exist in Cloudflare. Create it once in the dashboard (any IP); this program only updates existing records.
[WARN]   Note: '*.example.com' is the name of a wildcard record, not a pattern matching your existing subdomains. List those by name to keep them updated.
```

Troubleshooting docs (EN + ES) renamed to match the new message, plus a paragraph on the other half of the confusion: a wildcard never covers names that already have their own record (RFC 4592).

## Tests

Three new cases in `tests/main_test.sh` covering the message, the wildcard note, and that the note does not appear for regular names. Full suite: 128 passed. `./tools/validate.sh` clean (shellcheck, shfmt, yamllint, actionlint).

Verified end to end against a live zone.

Refs #133

https://claude.ai/code/session_01GvtPbCKbUQzQCNHaDAEcug

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/Cloudflare-DNS-Updater/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warnings when DNS records are missing, including guidance to create them in the dashboard before updating.
  * Clarified that wildcard names are treated as exact records and do not automatically match subdomains.

* **Documentation**
  * Updated troubleshooting guidance to reflect missing-record and wildcard behavior.

* **Tests**
  * Added coverage for missing records, wildcard explanations, and regular record messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->