### PR TITLE
fix(docs): repair the Person image URL and align with the canonical entity

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -70,13 +70,22 @@ const jsonLd = JSON.stringify({
 		{
 			// Mirrors the canonical Person node published at https://jmrp.io/#person
 			// so AI engines and search graphs reconcile both into one entity.
+			// Because the @id is shared, single-valued properties (jobTitle,
+			// description, image) MUST match the canonical values verbatim — a
+			// divergent value contradicts the entity instead of enriching it.
+			// `image` deliberately uses the GitHub avatar rather than an asset on
+			// jmrp.io: that site fingerprints its build output, so a hashed
+			// /_astro/ URL silently 404s on its next deploy (which is exactly how
+			// the previous value here rotted).
 			'@type': 'Person',
 			'@id': authorId,
 			name: 'José Manuel Requena Plens',
 			alternateName: 'jmrplens',
-			jobTitle: 'R&D Engineer',
+			jobTitle: 'R&D · Firmware & Software Engineer',
+			description:
+				'Firmware and software engineer in Valencia, Spain — industrial embedded systems, open-source tooling, and self-hosted infrastructure.',
 			url: authorUrl,
-			image: 'https://jmrp.io/_astro/mehome_landscape.Dg8oVd34.webp',
+			image: 'https://github.com/jmrplens.png',
 			worksFor: {
 				'@type': 'Organization',
 				name: 'Power Electronics',


### PR DESCRIPTION
## Problem

The docs site publishes a JSON-LD `Person` node under `@id: https://jmrp.io/#person` — the **same** identifier as the canonical entity on jmrp.io. The comment above it already says it mirrors that node, but three single-valued properties had drifted apart from it.

The serious one is `image`:

```
https://jmrp.io/_astro/mehome_landscape.Dg8oVd34.webp   →   HTTP 404
```

That is a fingerprinted Astro build asset. jmrp.io has rebuilt since, so the hash no longer exists and the shared entity was advertising a dead image. Any URL of that shape will rot again on the next deploy of that site.

## Change

- `image` → `https://github.com/jmrplens.png` (stable across deploys, HTTP 200, and already what the other project sites use).
- `jobTitle` → canonical value (was `"R&D Engineer"`).
- `description` → added; canonical value (was missing).
- Extended the comment to record *why* single-valued properties must mirror, and why a `/_astro/` URL is the wrong choice here.

`knowsAbout` and `sameAs` stay project-scoped on purpose — those are multi-valued and merge cleanly. `worksFor`, `identifier`, `url`, `name` and `alternateName` are untouched.

## Verification

```
astro build          21 page(s) built — Complete!
                     starlight-links-validator: all internal links valid
```

Person node re-parsed out of `dist/index.html` after the build:

```json
{
  "jobTitle": "R&D · Firmware & Software Engineer",
  "description": "Firmware and software engineer in Valencia, Spain — industrial embedded systems, open-source tooling, and self-hosted infrastructure.",
  "image": "https://github.com/jmrplens.png",
  "url": "https://jmrp.io"
}
```

`curl -o /dev/null -w '%{http_code}' -L https://github.com/jmrplens.png` → `200`.

https://claude.ai/code/session_01Ecf6hESxYdc7f1UV1vHrQU

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/Cloudflare-DNS-Updater/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

