### PR TITLE
fix(docs): drop worksFor from the shared Person entity

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -86,11 +86,10 @@ const jsonLd = JSON.stringify({
 				'Firmware and software engineer in Valencia, Spain — industrial embedded systems, open-source tooling, and self-hosted infrastructure.',
 			url: authorUrl,
 			image: 'https://github.com/jmrplens.png',
-			worksFor: {
-				'@type': 'Organization',
-				name: 'Power Electronics',
-				url: 'https://power-electronics.com/',
-			},
+			// No `worksFor` on purpose: employment is a property of the person,
+			// not of this project, and the canonical node at https://jmrp.io/#person
+			// asserts none. Declaring one only here would attach an employer to
+			// the shared entity that its own source of truth does not claim.
 			identifier: {
 				'@type': 'PropertyValue',
 				propertyID: 'ORCID',


### PR DESCRIPTION
## Problem

The docs site's JSON-LD `Person` node shares its `@id` with the canonical entity at `https://jmrp.io/#person`. It declared:

```json
"worksFor": { "@type": "Organization", "name": "Power Electronics", "url": "https://power-electronics.com/" }
```

The canonical node asserts **no** employer. So this project's docs site was attaching an employment claim to the shared entity that its own source of truth does not make.

Beyond the mismatch, an employer is a property of the *person*, not of this project — a project docs site is the wrong place to assert it, and the wrong place to have to keep it current when it changes.

## Change

- Removed `worksFor` from the `Person` node.
- Left a comment explaining why, so it isn't reintroduced.

`identifier` (ORCID), `knowsAbout`, `sameAs` and everything else are untouched. The separate project-as-Organization node and its `founder` reference are unaffected — that models the project, not employment.

## Verification

```
astro build   21 page(s) built — Complete!
```

Person node re-parsed from `dist/index.html` after the build:

```
worksFor present? false
keys: @type, @id, name, alternateName, jobTitle, description, url, image, identifier, knowsAbout, sameAs
```

https://claude.ai/code/session_01Ecf6hESxYdc7f1UV1vHrQU

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/Cloudflare-DNS-Updater/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

