### PR TITLE
fix(docs): drop the project-as-Organization node

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -14,7 +14,6 @@ import {
 	websiteId,
 	softwareId,
 	sourceCodeId,
-	organizationId,
 } from './src/site-meta.mjs';
 
 // Single-sourced project version (the repo-root VERSION file also drives releases)
@@ -190,27 +189,7 @@ const jsonLd = JSON.stringify({
 		// and jmrp.io describe the same node with the same values, instead of
 		// two hand-maintained copies that drift.
 		personNode,
-		{
-			// Project-as-Organization: the publisher entity for the site and its
-			// articles. `founder` links back to the maintainer Person, keeping the
-			// individual↔project relationship explicit for entity resolution.
-			'@type': 'Organization',
-			'@id': organizationId,
-			name: 'Cloudflare DNS Updater',
-			url: `${fullUrl}/`,
-			logo: {
-				'@type': 'ImageObject',
-				// Dedicated square brand mark (min 112×112 for Google's Organization
-				// logo guidance); the 1200×630 banner stays reserved for `image`/OG.
-				url: `${fullUrl}/logo-512.png`,
-				width: 512,
-				height: 512,
-			},
-			image: socialImage,
-			description: siteDescription,
-			founder: { '@id': authorId },
-			sameAs: [repositoryUrl],
-		},
+
 		{
 			'@type': 'WebSite',
 			'@id': websiteId,
@@ -219,7 +198,7 @@ const jsonLd = JSON.stringify({
 			description: siteDescription,
 			inLanguage: ['en', 'es'],
 			image: socialImage,
-			publisher: { '@id': organizationId },
+			publisher: { '@id': authorId },
 			about: { '@id': softwareId },
 		},
 		{

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -11,7 +11,6 @@ import {
 	authorId as PERSON_ID,
 	websiteId as WEBSITE_ID,
 	softwareId as SOFTWARE_ID,
-	organizationId as PROJECT_ID,
 } from "../site-meta.mjs";
 
 const SITE = import.meta.env.SITE ?? "https://jmrplens.github.io";
@@ -59,7 +58,7 @@ const techArticle = isHome
 			},
 			...(updated ? { datePublished: updated, dateModified: updated } : {}),
 			author: { "@id": PERSON_ID },
-			publisher: { "@id": PROJECT_ID },
+			publisher: { "@id": PERSON_ID },
 			isPartOf: { "@id": WEBSITE_ID },
 			about: { "@id": SOFTWARE_ID },
 		};

--- a/docs/src/site-meta.mjs
+++ b/docs/src/site-meta.mjs
@@ -11,8 +11,3 @@ export const authorId = `${authorUrl}/#person`;
 export const websiteId = `${fullUrl}/#website`;
 export const softwareId = `${repositoryUrl}#software`;
 export const sourceCodeId = `${repositoryUrl}#source-code`;
-// Project-as-Organization node: gives the docs/site a publisher entity distinct
-// from the individual maintainer (Person). Google's Article guidelines prefer an
-// Organization publisher with a logo, and it gives AI engines a project entity to
-// attach to alongside the author.
-export const organizationId = `${fullUrl}/#project`;


### PR DESCRIPTION
This site was the **only one of six** declaring an `Organization` for the project — and the only one whose `WebSite.publisher` was not the canonical Person.

```
libgen-mcp              publisher → https://jmrp.io/#person
gitlab-mcp-server       publisher → https://jmrp.io/#person
phonometry              publisher → https://jmrp.io/#person
cs-routeros-bouncer     publisher → https://jmrp.io/#person
jmrplens.github.io      publisher → https://jmrp.io/#person
this site               publisher → …/Cloudflare-DNS-Updater/#project   ← odd one out
```

## Why remove rather than replicate

**It was not accurate.** schema.org `Organization` describes *"a school, NGO, corporation, club"* — an entity with members and an existence of its own. There is none here: one person, one repository. `founder` compounded it, since nobody founded an organization; they wrote a Bash script.

**It carried nothing usable.** No address, no `contactPoint`, no `sameAs` beyond the repository the software node already declares. Organization signals need real business identity to do anything.

**It duplicated the software node on the wrong type.** `name`, `logo`, `image`, `description` and `sameAs` all restate what `SoftwareApplication` says under a shared `@id` — the same duplication that has drifted three separate times across this rollout, only on a type that does not fit.

**Its only structural job was being the publisher.** So removing it hands that role back to the Person, matching the other five sites and pointing the credit at the entity this rollout exists to consolidate.

## Changed in four places

- the `Organization` node itself
- `WebSite.publisher` → `authorId`
- the per-page article `publisher` in `Head.astro` → `PERSON_ID` (the other sites already use the Person here)
- the now-orphaned `organizationId` export in `site-meta.mjs`

## Verification

Built and re-parsed:

```
dist/index.html
  nodes    : Person, SoftwareApplication, SoftwareSourceCode, WebSite
  publisher: WebSite.publisher → {"@id":"https://jmrp.io/#person"}

dist/getting-started/index.html
  nodes    : BreadcrumbList, FAQPage, Person, SoftwareApplication,
             SoftwareSourceCode, TechArticle, WebSite
  publisher: WebSite.publisher   → {"@id":"https://jmrp.io/#person"}
             TechArticle.publisher → {"@id":"https://jmrp.io/#person"}
```

`SoftwareApplication` keeps all 25 properties, `image` and `screenshot` included — the project's visual identity lives there, on the correct type.

> `docs/public/logo-512.png` is now unreferenced from code but **left in place**: deleting an asset because one reference went away is a separate call.

https://claude.ai/code/session_01Ecf6hESxYdc7f1UV1vHrQU

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/Cloudflare-DNS-Updater/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

